### PR TITLE
[Project1/최용재] Notion 클로닝 프로젝트

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Clotion</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main id="app"></main>
+    <script src="./src/main.js" type="module"></script>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,1 @@
+export default function App({ $target }) {}

--- a/src/App.js
+++ b/src/App.js
@@ -124,7 +124,7 @@ export default function App({ $target }) {
     this.render();
   };
   this.render = async () => {
-    console.log(this.state);
+    //console.log(this.state);
     await fetchDocuments();
     //$editor.render();
     if (this.state.targetPage) {
@@ -145,7 +145,7 @@ export default function App({ $target }) {
       });
     } else {
       const [, pageId] = pathname.split("/");
-      console.log(pageId);
+      //console.log(pageId);
       const response = await request(`/documents/${pageId}`);
       this.setState({
         ...this.state,

--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,7 @@ export default function App({ $target }) {
         targetPageDocuments: null,
       });
       $editor.setState(createdPage);
-      push(`/documents/${createdPage.id}`);
+      push(`/${createdPage.id}`);
     },
   });
 
@@ -58,7 +58,7 @@ export default function App({ $target }) {
         targetPageDocuments: response.documents || [],
       });
       $editor.setState(response);
-      push(`/documents/${pageId}`);
+      push(`/${pageId}`);
     },
     onSubPageAdd: async (pageId) => {
       const createdPage = await request(`/documents`, {
@@ -74,7 +74,7 @@ export default function App({ $target }) {
         targetPageDocuments: createdPage.documents || null,
       });
       $editor.setState(createdPage);
-      push(`/documents/${createdPage.id}`);
+      push(`/${createdPage.id}`);
     },
     onPageDelete: async (pageId) => {
       await request(`/documents/${pageId}`, {

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ export default function App({ $target }) {
 
   const fetchDocuments = async () => {
     const documents = await request("/documents");
+    this.state = { ...this.state, pageList: documents };
     $pageList.setState(documents);
     //this.setState({ ...this.state, pageList: documents });
     //$pageList.setState(documents);
@@ -111,7 +112,10 @@ export default function App({ $target }) {
         });
         removeItem("temp-post");
         this.render();
-      }, 2000);
+      }, 1000);
+    },
+    validateLink: (linkId) => {
+      return this.state.pageList.some((page) => page.id === linkId);
     },
   });
 

--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,15 @@ export default function App({ $target }) {
   const $pageList = new PageList({
     $target: $pageManagerContainer,
     initialState: this.state.pageList,
+    onPageSelect: async (pageId) => {
+      const response = await request(`/documents/${pageId}`);
+      this.setState({
+        ...this.state,
+        targetPage: response,
+        targetPageDocuments: response.documents || [],
+      });
+      $editor.setState(response);
+    },
     onPageDelete: async (pageId) => {
       await request(`/documents/${pageId}`, {
         method: "DELETE",
@@ -39,6 +48,7 @@ export default function App({ $target }) {
   const $editor = new Editor({
     $target: $editorContainer,
     initialState: this.state.targetPage,
+    onEditing: (page) => {},
   });
 
   this.setState = (nextState) => {

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import Editor from "./components/Editor/Editor.js";
 import PageList from "./components/PageManager/PageList.js";
 import PageManagerHeader from "./components/PageManager/PageManagerHeader.js";
 import { removeItem, setItem } from "./util/storage.js";
+import { push, initRouter } from "./router.js";
 
 export default function App({ $target }) {
   this.state = {
@@ -42,6 +43,7 @@ export default function App({ $target }) {
         targetPageDocuments: null,
       });
       $editor.setState(createdPage);
+      push(`/documents/${createdPage.id}`);
     },
   });
 
@@ -56,6 +58,7 @@ export default function App({ $target }) {
         targetPageDocuments: response.documents || [],
       });
       $editor.setState(response);
+      push(`/documents/${pageId}`);
     },
     onSubPageAdd: async (pageId) => {
       const createdPage = await request(`/documents`, {
@@ -71,6 +74,7 @@ export default function App({ $target }) {
         targetPageDocuments: createdPage.documents || null,
       });
       $editor.setState(createdPage);
+      push(`/documents/${createdPage.id}`);
     },
     onPageDelete: async (pageId) => {
       await request(`/documents/${pageId}`, {
@@ -126,6 +130,31 @@ export default function App({ $target }) {
     }
   };
 
-  fetchDocuments();
-  this.render();
+  this.route = async () => {
+    await fetchDocuments();
+    const { pathname } = window.location;
+    if (pathname === "/") {
+      this.setState({
+        ...this.state,
+        targetPage: null,
+        targetPageDocuments: null,
+      });
+    } else {
+      const [, pageId] = pathname.split("/");
+      console.log(pageId);
+      const response = await request(`/documents/${pageId}`);
+      this.setState({
+        ...this.state,
+        targetPage: response,
+        targetPageDocuments: response.documents || [],
+      });
+      $editor.setState(response);
+    }
+  };
+  //fetchDocuments();
+  // window.addEventListener("popstate", async () => {
+  //   this.route();
+  // });
+  this.route();
+  initRouter(() => this.render());
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,1 +1,47 @@
-export default function App({ $target }) {}
+import { request } from "./api/api.js";
+import Editor from "./components/Editor/Editor.js";
+import PageList from "./components/PageManager/PageList.js";
+
+export default function App({ $target }) {
+  this.state = {
+    pageList: [],
+    targetPage: {},
+    targetPageDocuments: [],
+  };
+
+  const fetchDocuments = async () => {
+    const documents = await request("/documents");
+    $pageList.setState(documents);
+    //this.setState({ ...this.state, pageList: documents });
+    //$pageList.setState(documents);
+  };
+  const $editorContainer = document.createElement("div");
+  const $pageManagerContainer = document.createElement("div");
+
+  $target.appendChild($pageManagerContainer);
+  $target.appendChild($editorContainer);
+
+  const $pageList = new PageList({
+    $target: $pageManagerContainer,
+    initialState: this.state.pageList,
+  });
+  // const $editor = new Editor({
+  //   $target: $editorContainer,
+  //   initialState: this.state.targetPage,
+  // });
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+  this.render = () => {
+    console.log(this.state);
+    $pageList.render();
+    //$editor.render();
+    if (this.state.targetPage) {
+    } else {
+    }
+  };
+  fetchDocuments();
+  this.render();
+}

--- a/src/App.js
+++ b/src/App.js
@@ -15,33 +15,45 @@ export default function App({ $target }) {
     //this.setState({ ...this.state, pageList: documents });
     //$pageList.setState(documents);
   };
-  const $editorContainer = document.createElement("div");
   const $pageManagerContainer = document.createElement("div");
+  const $editorContainer = document.createElement("div");
 
+  $pageManagerContainer.className = "page_manager_container";
+  $editorContainer.className = "editor_container";
   $target.appendChild($pageManagerContainer);
   $target.appendChild($editorContainer);
 
   const $pageList = new PageList({
     $target: $pageManagerContainer,
     initialState: this.state.pageList,
+    onPageDelete: async (pageId) => {
+      await request(`/documents/${pageId}`, {
+        method: "DELETE",
+      });
+      this.setState({
+        ...this.state,
+        selectedDocument: null,
+      });
+    },
   });
-  // const $editor = new Editor({
-  //   $target: $editorContainer,
-  //   initialState: this.state.targetPage,
-  // });
+  const $editor = new Editor({
+    $target: $editorContainer,
+    initialState: this.state.targetPage,
+  });
 
   this.setState = (nextState) => {
     this.state = nextState;
     this.render();
   };
-  this.render = () => {
+  this.render = async () => {
     console.log(this.state);
-    $pageList.render();
+    await fetchDocuments();
     //$editor.render();
     if (this.state.targetPage) {
     } else {
     }
   };
+
   fetchDocuments();
   this.render();
 }

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,20 @@
+export const API_END_POINT = "https://kdt-frontend.programmers.co.kr";
+
+export const request = async (url, options = {}) => {
+  try {
+    const res = await fetch(`${API_END_POINT}${url}`, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        "x-username": "yongjaechoi",
+      },
+    });
+    if (res.ok) {
+      return await res.json();
+    }
+
+    throw new Error("API 처리중 뭔가 이상합니다!");
+  } catch (e) {
+    alert(e.message);
+  }
+};

--- a/src/components/Editor/ChildPageContainer.js
+++ b/src/components/Editor/ChildPageContainer.js
@@ -1,0 +1,35 @@
+import { push } from "../../router.js";
+
+export default function ChildPageContainer({
+  $target,
+  initialState,
+  onSubPageClick,
+}) {
+  const $childPageContainer = document.createElement("ul");
+  $childPageContainer.className = "child_page_container";
+  this.state = initialState;
+  $target.appendChild($childPageContainer);
+
+  this.render = () => {
+    //console.log(this.state);
+    $childPageContainer.innerHTML = `
+    ${this.state.map(
+      (page) =>
+        `<li data-id=${page.id} class='child_page'><span>${page.title}</span></li>`
+    )}
+    
+  `;
+  };
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+  this.render();
+  $childPageContainer.addEventListener("click", (e) => {
+    //console.log(e.target.closest("li").dataset.id);
+    const { id } = e.target.closest("li").dataset;
+    this.state.forEach((page) => {
+      if (+page.id === +id) onSubPageClick(page);
+    });
+  });
+}

--- a/src/components/Editor/ChildPageContainer.js
+++ b/src/components/Editor/ChildPageContainer.js
@@ -29,7 +29,7 @@ export default function ChildPageContainer({
     //console.log(e.target.closest("li").dataset.id);
     const { id } = e.target.closest("li").dataset;
     this.state.forEach((page) => {
-      if (+page.id === +id) onSubPageClick(page);
+      if (+page.id === +id) onSubPageClick(id);
     });
   });
 }

--- a/src/components/Editor/ChildPageContainer.js
+++ b/src/components/Editor/ChildPageContainer.js
@@ -25,9 +25,12 @@ export default function ChildPageContainer({
   this.render();
   $childPageContainer.addEventListener("click", (e) => {
     //console.log(e.target.closest("li").dataset.id);
-    const { id } = e.target.closest("li").dataset;
-    this.state.forEach((page) => {
-      if (+page.id === +id) onSubPageClick(id);
-    });
+    const $closestLi = e.target.closest("li");
+    if ($closestLi && $closestLi.dataset) {
+      const { id } = $closestLi.dataset;
+      this.state.forEach((page) => {
+        if (+page.id === +id) onSubPageClick(id);
+      });
+    }
   });
 }

--- a/src/components/Editor/ChildPageContainer.js
+++ b/src/components/Editor/ChildPageContainer.js
@@ -1,5 +1,3 @@
-import { push } from "../../router.js";
-
 export default function ChildPageContainer({
   $target,
   initialState,

--- a/src/components/Editor/ChildPageContainer.js
+++ b/src/components/Editor/ChildPageContainer.js
@@ -11,10 +11,12 @@ export default function ChildPageContainer({
   this.render = () => {
     //console.log(this.state);
     $childPageContainer.innerHTML = `
-    ${this.state.map(
-      (page) =>
-        `<li data-id=${page.id} class='child_page'><span>${page.title}</span></li>`
-    )}
+    ${this.state
+      .map(
+        (page) =>
+          `<li data-id=${page.id} class='child_page'><span>${page.title}</span></li>`
+      )
+      .join("")}
     
   `;
   };

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -1,4 +1,4 @@
-export default function Editor({ $target, initialState }) {
+export default function Editor({ $target, initialState, onEditing }) {
   const $editor = document.createElement("div");
   $editor.className = "editor";
   $editor.innerHTML = `
@@ -17,13 +17,17 @@ export default function Editor({ $target, initialState }) {
     $editor.querySelector("[name=title]").value = this.state.title;
 
     const $content = $editor.querySelector("[name=content]");
+    $editor.querySelector("[name=content]").innerHTML =
+      this.state.content || "";
   };
 
   $editor.querySelector("[name=title]").addEventListener("keyup", (e) => {
     this.setState({ ...this.state, title: e.target.value });
+    onEditing(this.state);
   });
 
   $editor.querySelector("[name=content]").addEventListener("input", (e) => {
     this.setState({ ...this.state, content: e.target.innerHTML });
+    onEditing(this.state);
   });
 }

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -3,7 +3,7 @@ export default function Editor({ $target, initialState }) {
   $editor.className = "editor";
   $editor.innerHTML = `
     <input class='editor_name' type="text" name="title" placeholder='제목을 입력하세요'/>
-    <div class='editor_content' name="content" contentEditable='true' placeholder='내용을 입력하세요.'></div>
+    <div class='editor_content' name="content" contentEditable='true'></div>
   `;
   this.state = initialState;
   $target.appendChild($editor);

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -2,7 +2,7 @@ export default function Editor({ $target, initialState }) {
   const $editor = document.createElement("div");
   $editor.className = "editor";
   $editor.innerHTML = `
-    <input class='editor_name' type="text" name="title" placeholder='제목을 입력하세요'/>
+    <input class='editor_title' type="text" name="title" placeholder='제목을 입력하세요'/>
     <div class='editor_content' name="content" contentEditable='true'></div>
   `;
   this.state = initialState;
@@ -12,5 +12,18 @@ export default function Editor({ $target, initialState }) {
     this.state = nextState;
     this.render();
   };
-  this.render = () => {};
+  this.render = () => {
+    console.log(this.state);
+    $editor.querySelector("[name=title]").value = this.state.title;
+
+    const $content = $editor.querySelector("[name=content]");
+  };
+
+  $editor.querySelector("[name=title]").addEventListener("keyup", (e) => {
+    this.setState({ ...this.state, title: e.target.value });
+  });
+
+  $editor.querySelector("[name=content]").addEventListener("input", (e) => {
+    this.setState({ ...this.state, content: e.target.innerHTML });
+  });
 }

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -12,13 +12,41 @@ export default function Editor({ $target, initialState, onEditing }) {
     this.state = nextState;
     this.render();
   };
+  this.parseContent = (content) => {
+    if (!content) return "";
+
+    const richContent = content
+      .split("<div>")
+      .map((line) => {
+        //console.log(line);
+        line = line.replace("</div>", "");
+        console.log(line);
+        if (line === "") return "";
+        if (line.indexOf("# ") === 0) {
+          console.log("1");
+          line = line.replace(/[\#]{1}(.+)/g, "<div><h1>$1</h1></div>");
+        } else if (line.indexOf("## ") === 0) {
+          line = line.replace(/[\#]{2}(.+)/g, "<div><h2>$1</h2></div>");
+        } else if (line.indexOf("### ") === 0) {
+          line = line.replace(/[\#]{3}(.+)/g, "<div><h3>$1</h3></div>");
+        } else if (line.indexOf("#### ") === 0) {
+          line = line.replace(/[\#]{4}(.+)/g, "<div><h4>$1</h4></div>");
+        } else {
+          line = `<div>${line}</div>`;
+        }
+        return line;
+      })
+      .join("");
+
+    return richContent;
+  };
   this.render = () => {
     console.log(this.state);
     $editor.querySelector("[name=title]").value = this.state.title;
 
     const $content = $editor.querySelector("[name=content]");
-    $editor.querySelector("[name=content]").innerHTML =
-      this.state.content || "";
+
+    $content.innerHTML = this.parseContent(this.state.content);
   };
 
   $editor.querySelector("[name=title]").addEventListener("keyup", (e) => {
@@ -29,5 +57,14 @@ export default function Editor({ $target, initialState, onEditing }) {
   $editor.querySelector("[name=content]").addEventListener("input", (e) => {
     this.setState({ ...this.state, content: e.target.innerHTML });
     onEditing(this.state);
+
+    const selection = window.getSelection();
+    const range = document.createRange();
+
+    selection.removeAllRanges();
+    range.selectNodeContents(e.target);
+    range.collapse(false);
+    selection.addRange(range);
+    e.target.focus();
   });
 }

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -1,3 +1,4 @@
+import { request } from "../../api/api.js";
 import { push } from "../../router.js";
 import ChildPageContainer from "./ChildPageContainer.js";
 
@@ -16,9 +17,10 @@ export default function Editor({
   const $childPageContainer = new ChildPageContainer({
     $target: $editor,
     initialState: (this.state && this.state.documents) || [],
-    onSubPageClick: (page) => {
-      this.setState(page);
-      push(`/${page.id}`);
+    onSubPageClick: async (id) => {
+      const pageInfo = await request(`/documents/${id}`);
+      this.setState(pageInfo);
+      push(`/${pageInfo.id}`);
     },
   });
 

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -1,0 +1,16 @@
+export default function Editor({ $target, initialState }) {
+  const $editor = document.createElement("div");
+  $editor.className = "editor";
+  $editor.innerHTML = `
+    <input class='editor_name' type="text" name="title" placeholder='제목을 입력하세요'/>
+    <div class='editor_content' name="content" contentEditable='true' placeholder='내용을 입력하세요.'></div>
+  `;
+  this.state = initialState;
+  $target.appendChild($editor);
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+  this.render = () => {};
+}

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -1,4 +1,9 @@
-export default function Editor({ $target, initialState, onEditing }) {
+export default function Editor({
+  $target,
+  initialState,
+  onEditing,
+  validateLink,
+}) {
   const $editor = document.createElement("div");
   $editor.className = "editor";
   $editor.innerHTML = `
@@ -18,10 +23,26 @@ export default function Editor({ $target, initialState, onEditing }) {
     const richContent = content
       .split("<div>")
       .map((line) => {
-        //console.log(line);
         line = line.replace("</div>", "");
         console.log(line);
+        const docLinkRegExp = /http:\/\/localhost:3000\/(\d+.*)/g;
+        const match = docLinkRegExp.exec(line);
+        if (match) {
+          validateLink(+match[1]);
+          if (validateLink(+match[1])) {
+            return `<div>${line}</div>`;
+          }
+        }
+        const boldRegExp = /[*]{2}(.*)[*]{2}/g;
+        // const italicRegExp = /[*]{1}(.*)[*]{1}/g;
+        if (boldRegExp.test(line))
+          line = line.replace(boldRegExp, "<strong>$1</strong> ");
+        // line = line.replace(italicRegExp, "<em>$1</em>");
+        console.log(line);
+
         if (line === "") return "";
+        if (line === "---") line = "<hr>";
+
         if (line.indexOf("# ") === 0) {
           console.log("1");
           line = line.replace(/[\#]{1}(.+)/g, "<div><h1>$1</h1></div>");

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -1,3 +1,6 @@
+import { push } from "../../router.js";
+import ChildPageContainer from "./ChildPageContainer.js";
+
 export default function Editor({
   $target,
   initialState,
@@ -10,11 +13,21 @@ export default function Editor({
     <input class='editor_title' type="text" name="title" placeholder='제목을 입력하세요'/>
     <div class='editor_content' name="content" contentEditable='true'></div>
   `;
-  this.state = initialState;
+  const $childPageContainer = new ChildPageContainer({
+    $target: $editor,
+    initialState: (this.state && this.state.documents) || [],
+    onSubPageClick: (page) => {
+      this.setState(page);
+      push(`/${page.id}`);
+    },
+  });
+
   $target.appendChild($editor);
 
+  this.state = initialState;
   this.setState = (nextState) => {
     this.state = nextState;
+    $childPageContainer.setState((this.state && this.state.documents) || []);
     this.render();
   };
   this.parseContent = (content) => {
@@ -24,7 +37,7 @@ export default function Editor({
       .split("<div>")
       .map((line) => {
         line = line.replace("</div>", "");
-        console.log(line);
+        //console.log(line);
         const docLinkRegExp = /http:\/\/localhost:3000\/(\d+.*)/g;
         const match = docLinkRegExp.exec(line);
         if (match) {
@@ -38,13 +51,12 @@ export default function Editor({
         if (boldRegExp.test(line))
           line = line.replace(boldRegExp, "<strong>$1</strong> ");
         // line = line.replace(italicRegExp, "<em>$1</em>");
-        console.log(line);
+        //console.log(line);
 
         if (line === "") return "";
         if (line === "---") line = "<hr>";
 
         if (line.indexOf("# ") === 0) {
-          console.log("1");
           line = line.replace(/[\#]{1}(.+)/g, "<div><h1>$1</h1></div>");
         } else if (line.indexOf("## ") === 0) {
           line = line.replace(/[\#]{2}(.+)/g, "<div><h2>$1</h2></div>");
@@ -62,7 +74,7 @@ export default function Editor({
     return richContent;
   };
   this.render = () => {
-    console.log(this.state);
+    //console.log(this.state);
     $editor.querySelector("[name=title]").value = this.state.title;
 
     const $content = $editor.querySelector("[name=content]");

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -24,46 +24,22 @@ export default function PageList({
               `
             <li data-id=${page.id} class='page_item'>
               <div class='item_seperator'>
-                <button class='toggle_button'>
-                ${
-                  page.documents && page.documents.length
-                    ? `<svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke-width="1.5"
-                      stroke='white'
-                      class="w-6 h-6"
-                    >
-                      <path
-                        stroke-linecap='round'
-                        stroke-linejoin='round'
-                        d='M19.5 8.25l-7.5 7.5-7.5-7.5'
-                    />
-                    </svg>`
-                    : `<svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke-width="1.5"
-                      stroke='white'
-                      class="w-6 h-6"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M8.25 4.5l7.5 7.5-7.5 7.5"
-                      />
-                    </svg>`
-                } 
-                  </button>
+                <div class='toggle_button'>
+                ${`<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="toggle_svg" stroke-width="1.5" stroke="gray" width="1rem" height="1rem">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+      </svg>`} 
+                  </div>
                 <div class='item_title'>${page.title}</div>
                 <div class='button_group'>
                   <div class='delete_button'>
-                    x
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white" width="1rem" height="1rem">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+</svg>
                   </div>
                   <div class='add_button'>
-                    +
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="white" width="1rem" height="1rem">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+</svg>
                   </div>
                 </div>
               </div>
@@ -80,18 +56,27 @@ export default function PageList({
   };
 
   this.render = () => {
-    console.log(this.state);
+    //console.log(this.state);
     $pageList.innerHTML = renderPageSubTree(this.state, true);
   };
 
   $pageList.addEventListener("click", (e) => {
     const $li = e.target.closest("li");
     const { id } = $li.dataset;
-    console.log(e.target.className);
     if (id === undefined) return;
-    const className = e.target.className;
-    if (className === "toggle_button") {
+    const $closestDiv = e.target.closest("div");
+    const { classList } = $closestDiv;
+    //console.log(e.target.closest("div"));
+    if (classList.contains("toggle_button")) {
       const $ul = $li.querySelector("ul");
+      if (classList.contains("toggled")) {
+        e.target.closest("div").classList.remove("toggled");
+        e.target.closest("svg").style.transform = "rotate(0)";
+      } else {
+        e.target.closest("div").classList.add("toggled");
+        e.target.closest("svg").style.transform = "rotate(90deg)";
+      }
+
       if ($ul) {
         if ($ul && $ul.style.display === "none") {
           $ul.style.display = "block";
@@ -99,11 +84,11 @@ export default function PageList({
           $ul.style.display = "none";
         }
       }
-    } else if (className === "item_title") {
+    } else if (classList.contains("item_title")) {
       onPageSelect(id);
-    } else if (className === "delete_button") {
+    } else if (classList.contains("delete_button")) {
       onPageDelete(id);
-    } else if (className === "add_button") {
+    } else if (classList.contains("add_button")) {
       const $ul = $li.querySelector("ul");
       if ($ul) {
         if ($ul && $ul.style.display === "none") {
@@ -114,7 +99,6 @@ export default function PageList({
       }
       onSubPageAdd(id);
     }
-    console.log(id);
   });
   this.render();
 }

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -1,4 +1,9 @@
-export default function PageList({ $target, initialState, onPageDelete }) {
+export default function PageList({
+  $target,
+  initialState,
+  onPageSelect,
+  onPageDelete,
+}) {
   const $pageList = document.createElement("div");
   $pageList.className = "page_list";
   $target.appendChild($pageList);
@@ -85,12 +90,19 @@ export default function PageList({ $target, initialState, onPageDelete }) {
   $pageList.addEventListener("click", (e) => {
     const $li = e.target.closest("li");
     const { id } = $li.dataset;
+    if (id === undefined) return;
     const className = $li.className;
+    console.log(className);
     if (className === "toggle_button") {
-    } else if (className === "item_title") {
+      console.log("toggle");
+    } else if (className === "page_item") {
+      console.log("item title");
+      onPageSelect(id);
     } else if (className === "delete_button") {
-      if (id) onPageDelete(id);
+      console.log("delete");
+      onPageDelete(id);
     } else if (className === "add_button") {
+      console.log("add");
     }
     console.log(id);
   });

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -25,19 +25,19 @@ export default function PageList({
             <li data-id=${page.id} class='page_item'>
               <div class='item_seperator'>
                 <div class='toggle_button'>
-                ${`<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="toggle_svg" stroke-width="1.5" stroke="gray" width="1rem" height="1rem">
+                ${`<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="toggle_svg" stroke-width="1.5" stroke="#64635E" width="15" height="15">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
       </svg>`} 
                   </div>
                 <div class='item_title'>${page.title}</div>
                 <div class='button_group'>
                   <div class='delete_button'>
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white" width="1rem" height="1rem">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="#64635E" width="15" height="15">
   <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
 </svg>
                   </div>
                   <div class='add_button'>
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="white" width="1rem" height="1rem">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="#64635E" width="15" height="15">
   <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
 </svg>
                   </div>

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -1,0 +1,86 @@
+export default function PageList({ $target, initialState }) {
+  const $pageList = document.createElement("div");
+
+  $target.appendChild($pageList);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+  const renderPageSubTree = (pageTree) => {
+    return `
+      <ul>
+        ${pageTree
+          .map(
+            (page) =>
+              `
+            <li data-id=${page.id} class='page_item'>
+              <div class='item_seperator'>
+                <button class='toggle_button'>
+                ${
+                  page.documents && page.documents.length
+                    ? `<svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                      class="w-6 h-6"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                      />
+                    </svg>`
+                    : `<svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                      class="w-6 h-6"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M8.25 4.5l7.5 7.5-7.5 7.5"
+                      />
+                    </svg>`
+                } 
+                  </button>
+                <div>${page.title}</div>
+                <div class='button_group'>
+                  <button class='delete_button'>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+                    </svg>
+                  </button>
+                  <button class='add_button'>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              ${
+                page.documents && page.documents.length
+                  ? renderPageSubTree(page.documents)
+                  : ""
+              }
+            </li>
+          `
+          )
+          .join("")}</ul>
+        `;
+  };
+
+  this.render = () => {
+    console.log(this.state);
+    $pageList.innerHTML = renderPageSubTree(this.state);
+  };
+
+  this.render();
+}

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -15,9 +15,9 @@ export default function PageList({
     this.state = nextState;
     this.render();
   };
-  const renderPageSubTree = (pageTree) => {
+  const renderPageSubTree = (pageTree, isRoot = false) => {
     return `
-      <ul>
+      <ul style='${isRoot ? "display:block" : "display:none"}'>
         ${pageTree
           .map(
             (page) =>
@@ -85,7 +85,7 @@ export default function PageList({
 
   this.render = () => {
     console.log(this.state);
-    $pageList.innerHTML = renderPageSubTree(this.state);
+    $pageList.innerHTML = renderPageSubTree(this.state, true);
   };
 
   $pageList.addEventListener("click", (e) => {
@@ -95,6 +95,14 @@ export default function PageList({
     if (id === undefined) return;
     const className = e.target.className;
     if (className === "toggle_button") {
+      const $ul = $li.querySelector("ul");
+      if ($ul) {
+        if ($ul && $ul.style.display === "none") {
+          $ul.style.display = "block";
+        } else {
+          $ul.style.display = "none";
+        }
+      }
     } else if (className === "item_title") {
       onPageSelect(id);
     } else if (className === "delete_button") {

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -2,6 +2,7 @@ export default function PageList({
   $target,
   initialState,
   onPageSelect,
+  onSubPageAdd,
   onPageDelete,
 }) {
   const $pageList = document.createElement("div");
@@ -90,19 +91,16 @@ export default function PageList({
   $pageList.addEventListener("click", (e) => {
     const $li = e.target.closest("li");
     const { id } = $li.dataset;
+    console.log(e.target.className);
     if (id === undefined) return;
-    const className = $li.className;
-    console.log(className);
+    const className = e.target.className;
     if (className === "toggle_button") {
-      console.log("toggle");
-    } else if (className === "page_item") {
-      console.log("item title");
+    } else if (className === "item_title") {
       onPageSelect(id);
     } else if (className === "delete_button") {
-      console.log("delete");
       onPageDelete(id);
     } else if (className === "add_button") {
-      console.log("add");
+      onSubPageAdd(id);
     }
     console.log(id);
   });

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -17,7 +17,7 @@ export default function PageList({
   };
   const renderPageSubTree = (pageTree, isRoot = false) => {
     return `
-      <ul style='${isRoot ? "display:block" : "display:none"}'>
+      <ul >
         ${pageTree
           .map(
             (page) =>
@@ -59,16 +59,12 @@ export default function PageList({
                   </button>
                 <div class='item_title'>${page.title}</div>
                 <div class='button_group'>
-                  <button class='delete_button'>
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
-                    </svg>
-                  </button>
-                  <button class='add_button'>
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-                    </svg>
-                  </button>
+                  <div class='delete_button'>
+                    x
+                  </div>
+                  <div class='add_button'>
+                    +
+                  </div>
                 </div>
               </div>
               ${
@@ -108,6 +104,14 @@ export default function PageList({
     } else if (className === "delete_button") {
       onPageDelete(id);
     } else if (className === "add_button") {
+      const $ul = $li.querySelector("ul");
+      if ($ul) {
+        if ($ul && $ul.style.display === "none") {
+          $ul.style.display = "block";
+        } else {
+          $ul.style.display = "none";
+        }
+      }
       onSubPageAdd(id);
     }
     console.log(id);

--- a/src/components/PageManager/PageList.js
+++ b/src/components/PageManager/PageList.js
@@ -1,6 +1,6 @@
-export default function PageList({ $target, initialState }) {
+export default function PageList({ $target, initialState, onPageDelete }) {
   const $pageList = document.createElement("div");
-
+  $pageList.className = "page_list";
   $target.appendChild($pageList);
 
   this.state = initialState;
@@ -26,21 +26,21 @@ export default function PageList({ $target, initialState }) {
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke-width="1.5"
-                      stroke="currentColor"
+                      stroke='white'
                       class="w-6 h-6"
                     >
                       <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-                      />
+                        stroke-linecap='round'
+                        stroke-linejoin='round'
+                        d='M19.5 8.25l-7.5 7.5-7.5-7.5'
+                    />
                     </svg>`
                     : `<svg
                       xmlns="http://www.w3.org/2000/svg"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke-width="1.5"
-                      stroke="currentColor"
+                      stroke='white'
                       class="w-6 h-6"
                     >
                       <path
@@ -51,7 +51,7 @@ export default function PageList({ $target, initialState }) {
                     </svg>`
                 } 
                   </button>
-                <div>${page.title}</div>
+                <div class='item_title'>${page.title}</div>
                 <div class='button_group'>
                   <button class='delete_button'>
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -82,5 +82,17 @@ export default function PageList({ $target, initialState }) {
     $pageList.innerHTML = renderPageSubTree(this.state);
   };
 
+  $pageList.addEventListener("click", (e) => {
+    const $li = e.target.closest("li");
+    const { id } = $li.dataset;
+    const className = $li.className;
+    if (className === "toggle_button") {
+    } else if (className === "item_title") {
+    } else if (className === "delete_button") {
+      if (id) onPageDelete(id);
+    } else if (className === "add_button") {
+    }
+    console.log(id);
+  });
   this.render();
 }

--- a/src/components/PageManager/PageManagerHeader.js
+++ b/src/components/PageManager/PageManagerHeader.js
@@ -1,7 +1,7 @@
 export default function PageManagerHeader({ $target, onNewPageAdd }) {
-  const $pageAddButton = document.createElement("button");
+  const $pageAddButton = document.createElement("div");
   $pageAddButton.className = "page_manager_add_button";
-  $pageAddButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="black" height="10" width="10">
+  $pageAddButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="#64635E" height="15" width="15">
   <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
 </svg>`;
   $target.appendChild($pageAddButton);

--- a/src/components/PageManager/PageManagerHeader.js
+++ b/src/components/PageManager/PageManagerHeader.js
@@ -1,12 +1,9 @@
 export default function PageManagerHeader({ $target, onNewPageAdd }) {
   const $pageAddButton = document.createElement("button");
   $pageAddButton.className = "page_manager_add_button";
-  $pageAddButton.innerHTML = `
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  $pageAddButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="black" height="10" width="10">
   <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-</svg>
-
-  `;
+</svg>`;
   $target.appendChild($pageAddButton);
 
   $pageAddButton.addEventListener("click", async (e) => {

--- a/src/components/PageManager/PageManagerHeader.js
+++ b/src/components/PageManager/PageManagerHeader.js
@@ -1,0 +1,15 @@
+export default function PageManagerHeader({ $target, onNewPageAdd }) {
+  const $pageAddButton = document.createElement("button");
+  $pageAddButton.className = "page_manager_add_button";
+  $pageAddButton.innerHTML = `
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+</svg>
+
+  `;
+  $target.appendChild($pageAddButton);
+
+  $pageAddButton.addEventListener("click", async (e) => {
+    await onNewPageAdd();
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,5 @@
+import App from "./App.js";
+
+const $target = document.querySelector("#app");
+
+new App({ $target });

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import App from "./App.js";
 
-const $target = document.querySelector("#app");
+const $app = document.querySelector("#app");
 
-new App({ $target });
+new App({ $target: $app });

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,21 @@
+const ROUTE_CHANGE_EVENT_NAME = "route-change";
+
+export const initRouter = (onRoute) => {
+  window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
+    const { nextUrl } = e.detail;
+    if (nextUrl) {
+      history.pushState(null, null, nextUrl);
+      onRoute();
+    }
+  });
+};
+
+export const push = (nextUrl) => {
+  window.dispatchEvent(
+    new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
+      detail: {
+        nextUrl,
+      },
+    })
+  );
+};

--- a/src/router.js
+++ b/src/router.js
@@ -1,12 +1,12 @@
 const ROUTE_CHANGE_EVENT_NAME = "route-change";
 
-export const initRouter = (onRoute) => {
+export const initRouter = (onRoute = () => {}) => {
   window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
     const { nextUrl } = e.detail;
     if (nextUrl) {
       history.pushState(null, null, nextUrl);
-      onRoute();
     }
+    onRoute();
   });
 };
 

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -1,0 +1,18 @@
+const storage = window.localStorage;
+
+export const getItem = (key, defaultValue) => {
+  try {
+    const storedValue = storage.getItem(key);
+    return storedValue ? JSON.parse(storedValue) : defaultValue;
+  } catch (e) {
+    return defaultValue;
+  }
+};
+
+export const setItem = (key, value) => {
+  storage.setItem(key, JSON.stringify(value));
+};
+
+export const removeItem = (key) => {
+  storage.removeItem(key);
+};

--- a/style.css
+++ b/style.css
@@ -93,9 +93,12 @@ ol {
   .editor_title,
   .editor_title:focus {
     width: 100%;
-    padding: 1rem;
+    margin-top: 1rem;
+    padding-bottom: 1rem;
     border: none;
     outline: none;
+    font-size: 1.7rem;
+    font-weight: 800;
     border-bottom: 1px solid black;
   }
 

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ ol {
   padding: 0.5rem 0 0.5rem 1rem;
 }
 .page_manager_container {
-  width: 200px;
+  min-width: 200px;
   padding: 1rem;
   background-color: #fbfbfa;
 
@@ -44,7 +44,34 @@ ol {
     }
   }
 }
+.add_button {
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  background-color: darkslategray;
+  color: white;
+  padding: 4px;
 
+  line-height: 10px;
+  text-align: center;
+  span {
+    display: block;
+  }
+}
+.delete_button {
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  background-color: darkslategray;
+  color: white;
+  padding: 4px;
+
+  line-height: 10px;
+  text-align: center;
+  span {
+    display: block;
+  }
+}
 .editor_container {
   width: 100%;
   height: 100%;
@@ -58,82 +85,10 @@ ol {
     padding: 1rem;
   }
   .editor_content {
+    display: inline-block;
     width: 100%;
     height: 400px;
     padding: 1rem;
     border: solid black 1px;
   }
-}
-
-.PageItem {
-  display: flex;
-  flex-direction: column;
-  font-size: 1rem;
-  /* .addButton {
-    display: hidden;
-    width: 15px;
-    height: 15px;
-  } */
-  .unToggled {
-    display: none;
-  }
-  .subList {
-    display: flex;
-    flex-direction: row;
-  }
-  .innerContainer {
-    display: flex;
-    align-items: center;
-    .addButton {
-      display: none;
-    }
-  }
-}
-
-.innerContainer {
-  border-radius: 5px;
-}
-.innerContainer:hover {
-  position: relative;
-  background-color: lightgray;
-  .addButton {
-    position: absolute;
-    right: 10px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 15px;
-    height: 15px;
-    background-color: lightslategray;
-    border-radius: 3px;
-  }
-  .delButton {
-    position: absolute;
-    right: 30px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 15px;
-    height: 15px;
-    background-color: lightslategray;
-    border-radius: 3px;
-  }
-}
-.toggleButton {
-  transition: all 0.5s;
-}
-
-.sideBar {
-  width: 200px;
-  height: 100%;
-  padding: 0 5px;
-  background-color: #fbfbfa;
-}
-
-.editPage {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -17,7 +17,15 @@ ol {
   min-width: 200px;
   padding: 1rem;
   background-color: #fbfbfa;
-
+  .page_manager_add_button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 5px;
+    background-color: #d4d4d3;
+  }
   .item_seperator {
     padding: 0;
     display: flex;
@@ -57,30 +65,22 @@ ol {
 }
 
 .add_button {
-  width: 1.5rem;
-  height: 1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
   border-radius: 5px;
-  background-color: darkslategray;
-  color: white;
-
-  line-height: 10px;
-  text-align: center;
-  span {
-    display: block;
-  }
+  background-color: #d4d4d3;
 }
 .delete_button {
-  width: 1.5rem;
-  height: 1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
   border-radius: 5px;
-  background-color: darkslategray;
-  color: white;
-
-  line-height: 10px;
-  text-align: center;
-  span {
-    display: block;
-  }
+  background-color: #d4d4d3;
 }
 .editor_container {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -53,7 +53,7 @@ ol {
 .editor {
   width: 100%;
 
-  .editor_name {
+  .editor_title {
     width: 100%;
     padding: 1rem;
   }

--- a/style.css
+++ b/style.css
@@ -1,0 +1,129 @@
+html,
+body {
+  height: 100%;
+  width: 100%;
+  #app {
+    display: flex;
+    height: 100%;
+    width: 100%;
+  }
+}
+ul,
+ol {
+  list-style: none;
+  padding: 0.5rem 1rem;
+}
+.page_manager_container {
+  width: 200px;
+  padding: 1rem;
+  background-color: #fbfbfa;
+
+  .item_seperator {
+    display: flex;
+    width: 100%;
+    .toggle_button {
+    }
+    .button_group {
+      display: none;
+    }
+  }
+  .item_seperator:hover {
+    .button_group {
+      display: flex;
+      align-items: center;
+    }
+  }
+}
+
+.editor_container {
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+}
+.editor {
+  width: 100%;
+
+  .editor_name {
+    width: 100%;
+    padding: 1rem;
+  }
+  .editor_content {
+    width: 100%;
+    height: 400px;
+    padding: 1rem;
+    border: solid black 1px;
+  }
+}
+
+.PageItem {
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+  /* .addButton {
+    display: hidden;
+    width: 15px;
+    height: 15px;
+  } */
+  .unToggled {
+    display: none;
+  }
+  .subList {
+    display: flex;
+    flex-direction: row;
+  }
+  .innerContainer {
+    display: flex;
+    align-items: center;
+    .addButton {
+      display: none;
+    }
+  }
+}
+
+.innerContainer {
+  border-radius: 5px;
+}
+.innerContainer:hover {
+  position: relative;
+  background-color: lightgray;
+  .addButton {
+    position: absolute;
+    right: 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 15px;
+    height: 15px;
+    background-color: lightslategray;
+    border-radius: 3px;
+  }
+  .delButton {
+    position: absolute;
+    right: 30px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 15px;
+    height: 15px;
+    background-color: lightslategray;
+    border-radius: 3px;
+  }
+}
+.toggleButton {
+  transition: all 0.5s;
+}
+
+.sideBar {
+  width: 200px;
+  height: 100%;
+  padding: 0 5px;
+  background-color: #fbfbfa;
+}
+
+.editPage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@ body {
 ul,
 ol {
   list-style: none;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0 0.5rem 1rem;
 }
 .page_manager_container {
   width: 200px;
@@ -20,16 +20,26 @@ ol {
 
   .item_seperator {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
     width: 100%;
+    border: solid black 1px;
     .toggle_button {
     }
+    .item_title {
+      width: 100%;
+      border: solid 1px black;
+    }
     .button_group {
-      display: none;
+      display: flex;
+      visibility: hidden;
+      align-items: center;
     }
   }
   .item_seperator:hover {
     .button_group {
       display: flex;
+      visibility: visible;
       align-items: center;
     }
   }

--- a/style.css
+++ b/style.css
@@ -19,16 +19,18 @@ ol {
   background-color: #fbfbfa;
 
   .item_seperator {
+    padding: 0;
     display: flex;
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    border: solid black 1px;
-    .toggle_button {
-    }
+    height: 1.5rem;
+    /* border: solid black 1px; */
+
     .item_title {
       width: 100%;
-      border: solid 1px black;
+      height: 100%;
+      /* border: solid 1px black; */
     }
     .button_group {
       display: flex;
@@ -44,13 +46,22 @@ ol {
     }
   }
 }
+.toggle_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  transition: all 1s;
+  /* border: solid black 1px; */
+}
+
 .add_button {
-  width: 10px;
-  height: 10px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 5px;
   background-color: darkslategray;
   color: white;
-  padding: 4px;
 
   line-height: 10px;
   text-align: center;
@@ -59,12 +70,11 @@ ol {
   }
 }
 .delete_button {
-  width: 10px;
-  height: 10px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 5px;
   background-color: darkslategray;
   color: white;
-  padding: 4px;
 
   line-height: 10px;
   text-align: center;
@@ -80,15 +90,39 @@ ol {
 .editor {
   width: 100%;
 
-  .editor_title {
+  .editor_title,
+  .editor_title:focus {
     width: 100%;
     padding: 1rem;
+    border: none;
+    outline: none;
+    border-bottom: 1px solid black;
   }
+
   .editor_content {
     display: inline-block;
     width: 100%;
-    height: 400px;
+    height: fit-content;
     padding: 1rem;
-    border: solid black 1px;
+    /* border: solid black 1px; */
   }
+  .editor_content:focus {
+    outline: none;
+  }
+}
+.child_page_container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+.child_page {
+  width: 100px;
+  height: 110px;
+  border: solid black 1px;
+  border-radius: 10px;
+  text-align: center;
+  padding-top: 10px;
+  font-size: 1.1rem;
+  font-weight: 800;
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

노션 클로닝 프로젝트입니다

[배포 링크](https://fedc-5-5-deploy.vercel.app/)
### 데모
- 루트 페이지 추가 / 자식 페이지 추
![notion_add](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/88219703/5cc1ad92-d128-4898-8ab0-95c14ae69021)
- 페이지 리스트 항목 토글
![notion_toggle](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/88219703/ee2bf872-c37a-4312-8574-849a3dccaf6d)
- 루트 페이지 삭제 / 자식 페이지 삭제
![notion_delete](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/88219703/5ba10843-7598-4044-87e6-74f819ee4fb9)
- 페이지 제목, 내용 업데이트
![notion_pageupdate](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/88219703/244abf7f-c454-4990-a37d-51268b08cdde)
- 자식 페이지 링크
![notion_childLink](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/88219703/c45240a5-7f08-4b0b-a6b8-be01f8cc37ac)
- 라우팅
![notion_routing](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/88219703/d3463573-4e22-4dc2-9431-ddafa6bd666a)
- 에디터
![notion_editor](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/88219703/1a77763b-ced4-4501-9678-98dcdf147fec)

### 프로젝트 구조
```
root
├─ README.md
├─ index.html
├─ src
│   ├─ api
│   │   └─ api.js
│   ├─ components
│   │   ├─ Editor
│   │   │   ├─ ChildPageContainer.js
│   │   │   └─ Editor.js
│   │   └─ PageManager
│   │   │   ├─ PageList.js   
│   │   │   ├─ PageManagerHeader.js       
│   │   └─ util
│   │        └─storage.js
│   ├─ App.js
│   ├─ main.js
│   └─ router.js
└─ style.css
```

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- [x] 화면 좌측에 Root Documents를 불러오는 API를 통해 루트 Documents를 렌더링합니다.

- [x] Root Document를 클릭하면 오른쪽 편집기 영역에 해당 Document의 Content를 렌더링합니다.

- [x] 해당 Root Document에 하위 Document가 있는 경우, 해당 Document 아래에 트리 형태로 렌더링 합니다.

- [x] Document Tree에서 각 Document 우측에는 + 버튼이 있습니다. 해당 버튼을 클릭하면, 클릭한 Document의 하위 Document로 새 Document를 생성하고 편집화면으로 넘깁니다.

- [x] 편집기에는 기본적으로 저장 버튼이 없습니다. Document Save API를 이용해 지속적으로 서버에 저장되도록 합니다.

- [x] History API를 이용해 SPA 형태로 만듭니다.
> - /{documentId} 로 접속시, 해당 Document 의 content를 불러와 편집기에 로딩합니다.

- [x] 루트 URL 접속 시엔 별다른 편집기 선택이 안 된 상태입니다.

- [x] 기본적으로 편집기는 textarea 기반으로 단순한 텍스트 편집기로 시작하되, 여력이 되면 div와 contentEditable을 조합해서 좀 더 Rich한 에디터를 만들어봅니다.
> - [# ], [## ], [### ], [#### ], [---], [\*\*(bold할 구문) \*\*] 마크다운 언어를 html로 변환하는 기능을 지원합니다

- [x] 편집기 최하단에는 현재 편집 중인 Document의 하위 Document 링크를 렌더링하도록 추가합니다.

- [ ] 편집기 내에서 다른 Document name을 적은 경우, 자동으로 해당 Document의 편집 페이지로 이동하는 링크를 거는 기능을 추가합니다. 
> 시도했으나, richContent 변환 과정에서 각종 버그로 기능을 포기했습니다.



## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 컴포넌트 분리 상태가 적절한 지 궁금합니다
- 코드의 가독성이 좋은지 궁금합니다
- 사이드바의 pageList는 낙관적 상태 업데이트 없이 매번 data fetching을 합니다. 하지만 pageList의 전체 상태를 낙관적으로 업데이트하려고 했지만 실패했습니다. 매번 fetching해오지 않고도 pageList를 최신화할 수 있는 state 변경 흐름이 궁금합니다.
- ToDoList 과제의 유효검사처럼 조건보다 오버해서 구현한 부분이 있는지 궁금합니다. 반대로 부족한 부분도 궁금합니다.
- 커밋할 때 이것 저것을 test하기 위해 작성했지만 커밋으로 기록할 필요가 있는 코드가 종종 있습니다. 해당 코드는 현재 test: 로 커밋하고 있는데 혹시 더 좋은 컨벤션이 있을까요? 
- 현재 contentEditable Editor는 내용 중간의 내용을 수정할 시에 1회 keydown 이후 맨 끝으로 cursor가 이동합니다. contentEditable 내용이 변경될 때마다 innerHTML을 새로 설정하면서 파생되는 문제 중 하나인 것 같습니다. 내용의 끝이 아닌 부분을 수정할 때 cursor position이 자연스럽도록 하는 방법이 궁금합니다.