### PR TITLE
[Project1/이진아] Notion 클로닝 프로젝트

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+ <html lang="ko">
+ <head>
+     <meta charset="UTF-8">
+     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+     <title>Notion Clone</title>
+ </head>
+ <body>
+     <main id="app"></main>
+     <script src="/src/main.js" type="module"></script>
+ </body>
+ </html>

--- a/index.html
+++ b/index.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
- <html lang="ko">
- <head>
-     <meta charset="UTF-8">
-     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-     <title>Notion Clone</title>
- </head>
- <body>
-     <main id="app"></main>
-     <script src="/src/main.js" type="module"></script>
- </body>
- </html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notion Clone</title>
+    <link rel="stylesheet" href="/src/styles/reset.css">
+    <link rel="stylesheet" href="/src/styles/style.css">
+    <script src="https://kit.fontawesome.com/84a7c31301.js" crossorigin="anonymous"></script>
+</head>
+<body>
+    <main id="app"></main>
+    <script src="/src/main.js" type="module"></script>
+</body>
+</html>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,0 +1,9 @@
+import Sidebar from './Sidebar.js';
+
+ export default function App({ $target }) {
+   isNew(new.target);
+
+   new Sidebar({
+     $target,
+   });
+ }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,9 +1,37 @@
 import Sidebar from './Sidebar.js';
+import DocumentEditPage from './DocumentEditPage.js';
+import { ROUTE_DOCUMENTS } from '../utils/contants.js';
+import { isNew } from '../utils/helper.js';
+import { initRouter } from '../utils/router.js';
 
- export default function App({ $target }) {
+export default function App({ $target }) {
    isNew(new.target);
 
    new Sidebar({
      $target,
    });
- }
+
+   const documentEditPage = new DocumentEditPage({
+     $target,
+     initialState: {
+       documentId: null,
+       document: {
+         title: '',
+         content: '',
+       },
+     },
+   });
+
+   this.route = () => {
+     const { pathname } = window.location;
+
+     if (pathname.indexOf(ROUTE_DOCUMENTS) === 0) {
+       const [, , documentId] = pathname.split('/');
+       documentEditPage.setState({ documentId });
+     }
+   };
+
+   this.route();
+
+   initRouter(() => this.route());
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,37 +1,144 @@
-import Sidebar from './Sidebar.js';
-import DocumentEditPage from './DocumentEditPage.js';
-import { ROUTE_DOCUMENTS } from '../utils/contants.js';
-import { isNew } from '../utils/helper.js';
-import { initRouter } from '../utils/router.js';
+import Sidebar from './Sidebar/Sidebar.js';
+import DocumentEditPage from './DocumentEditPage/DocumentEditPage.js';
+
+import { ID, KEY, MESSAGE } from '../utils/constants.js';
+import {
+  generateRouteDocuments,
+  isNew,
+  setDocumentTitle,
+} from '../utils/helper.js';
+import { initRouter, push } from '../utils/router.js';
+import { fetchDocuments } from '../utils/api.js';
+import {
+  getStorageItem,
+  removeStorageItem,
+  setStorageItem,
+} from '../utils/storage.js';
 
 export default function App({ $target }) {
-   isNew(new.target);
+  isNew(new.target);
 
-   new Sidebar({
-     $target,
-   });
+  let timer = null;
 
-   const documentEditPage = new DocumentEditPage({
-     $target,
-     initialState: {
-       documentId: null,
-       document: {
-         title: '',
-         content: '',
-       },
-     },
-   });
+  const onAdd = async () => {
+    push(generateRouteDocuments(ID.NEW));
 
-   this.route = () => {
-     const { pathname } = window.location;
+    const createdDocument = await fetchDocuments('', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: '',
+        parent: getStorageItem(KEY.NEW_PARENT, null),
+      }),
+    });
 
-     if (pathname.indexOf(ROUTE_DOCUMENTS) === 0) {
-       const [, , documentId] = pathname.split('/');
-       documentEditPage.setState({ documentId });
-     }
-   };
+    history.replaceState(
+      null,
+      null,
+      generateRouteDocuments(createdDocument.id)
+    );
+    removeStorageItem(KEY.NEW_PARENT);
 
-   this.route();
+    documentEditPage.setState({ documentId: createdDocument.id });
 
-   initRouter(() => this.route());
+    sidebar.setState({
+      selectedId: parseInt(createdDocument.id),
+    });
+  };
+
+  const onDelete = async (currentDocumentId, removedDocumentId) => {
+    if (removedDocumentId === ID.DEFAULT_DOCUMENT) {
+      alert(MESSAGE.DO_NOT_DELETE_FIRST_PAGE);
+      return;
+    }
+
+    if (!confirm(MESSAGE.DELETE_PAGE)) return;
+
+    await fetchDocuments(removedDocumentId, {
+      method: 'DELETE',
+    });
+
+    const openedItems = getStorageItem(KEY.OPENED_ITEMS, []);
+    setStorageItem(
+      KEY.OPENED_ITEMS,
+      openedItems.filter((item) => item !== removedDocumentId)
+    );
+
+    if (currentDocumentId === removedDocumentId) {
+      documentEditPage.setState({ documentId: ID.DEFAULT_DOCUMENT });
+      push(generateRouteDocuments(ID.DEFAULT_DOCUMENT));
+    } else {
+      documentEditPage.setState({ documentId: currentDocumentId });
+    }
+
+    sidebar.render();
+  };
+
+  const onEdit = ({ id, title, content }) => {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(async () => {
+      const editedDocument = await fetchDocuments(id, {
+        method: 'PUT',
+        body: JSON.stringify({ title, content }),
+      });
+
+      documentEditPage.setState({
+        documentId: editedDocument.id,
+        document: editedDocument,
+      });
+
+      sidebar.render();
+    }, 1000);
+  };
+
+  const sidebar = new Sidebar({
+    $target,
+    initialState: {
+      selectedId: null,
+    },
+    onAdd,
+    onDelete,
+  });
+
+  const documentEditPage = new DocumentEditPage({
+    $target,
+    initialState: {
+      documentId: null,
+      document: {
+        title: '',
+        content: '',
+      },
+    },
+    onDelete,
+    onEdit,
+  });
+
+  this.route = () => {
+    const { pathname } = window.location;
+
+    if (pathname === '/') {
+      setDocumentTitle('Notion');
+      return;
+    }
+
+    if (pathname.indexOf('/documents') !== 0) return;
+
+    const [, , documentId] = pathname.split('/');
+    documentEditPage.setState({
+      documentId: isNaN(documentId) ? documentId : parseInt(documentId),
+    });
+
+    if (!isNaN(documentId)) {
+      sidebar.setState({
+        selectedId: parseInt(documentId),
+      });
+    }
+  };
+
+  window.addEventListener('popstate', () => this.route());
+
+  this.route();
+
+  initRouter(() => this.route());
 }

--- a/src/components/DocumentEditPage/DocumentEditPage.js
+++ b/src/components/DocumentEditPage/DocumentEditPage.js
@@ -1,0 +1,125 @@
+import Editor from './Editor.js';
+
+ import { request } from '../utils/api.js';
+ import { NEW, ROUTE_DOCUMENTS } from '../utils/contants.js';
+ import { isNew } from '../utils/helper.js';
+ import { getItem, removeItem, setItem } from '../utils/storage.js';
+
+ export default function DocumentEditPage({ $target, initialState }) {
+   isNew(new.target);
+
+   const $page = document.createElement('div');
+
+   this.state = initialState;
+
+   let documentLocalSaveKey = `temp-document-${this.state.documentId}`;
+
+   const savedDocument = getItem(documentLocalSaveKey, {
+     title: '',
+     content: '',
+   });
+
+   let timer = null;
+
+   const editor = new Editor({
+     $target: $page,
+     initialState: savedDocument,
+     onEditing: (document) => {
+       if (timer !== null) {
+         clearTimeout(timer);
+       }
+       timer = setTimeout(async () => {
+         setItem(documentLocalSaveKey, {
+           ...document,
+           tempSaveDate: new Date(),
+         });
+
+         if (this.state.documentId === NEW) {
+           const createdDocument = await request(ROUTE_DOCUMENTS, {
+             method: 'POST',
+             body: JSON.stringify(document),
+           });
+           history.replaceState(
+             null,
+             null,
+             `${ROUTE_DOCUMENTS}/${createdDocument.id}`
+           );
+           removeItem(documentLocalSaveKey);
+
+           this.setState({
+             documentId: createdDocument.id,
+           });
+         } else {
+           await request(`${ROUTE_DOCUMENTS}/${document.id}`, {
+             method: 'PUT',
+             body: JSON.stringify(document),
+           });
+           removeItem(documentLocalSaveKey);
+         }
+       }, 2000);
+     },
+   });
+
+   this.setState = async (nextState) => {
+     if (
+       this.state.documentId === nextState.documentId &&
+       !this.state.document
+     ) {
+       this.state = nextState;
+       editor.setState(
+         this.state.document || {
+           title: '',
+           content: '',
+         }
+       );
+       this.render();
+       return;
+     }
+
+     documentLocalSaveKey = `temp-document-${nextState.documentId}`;
+     this.state = nextState;
+
+     if (this.state.documentId === NEW) {
+       const document = getItem(documentLocalSaveKey, {
+         title: '',
+         content: '',
+       });
+       editor.setState(document);
+       this.render();
+     } else {
+       await fetchDocument();
+     }
+   };
+
+   this.render = () => {
+     $target.appendChild($page);
+   };
+
+   const fetchDocument = async () => {
+     const { documentId } = this.state;
+     const document = await request(`${ROUTE_DOCUMENTS}/${documentId}`);
+
+     const tempDocument = getItem(documentLocalSaveKey, {
+       title: '',
+       content: '',
+     });
+
+     if (
+       tempDocument.tempSaveDate &&
+       tempDocument.tempSaveDate > document.updatedAt
+     ) {
+       if (confirm('저장되지 않은 임시 데이터가 있습니다. 불러올까요?')) {
+         this.setState({
+           ...this.state,
+           document: tempDocument,
+         });
+         return;
+       }
+     }
+
+     this.setState({
+       ...this.state,
+       document,
+     });
+   };
+ }

--- a/src/components/DocumentEditPage/DocumentEditPage.js
+++ b/src/components/DocumentEditPage/DocumentEditPage.js
@@ -1,7 +1,7 @@
 import Editor from './Editor.js';
 
  import { request } from '../utils/api.js';
- import { NEW, NEWPARENT, ROUTE_DOCUMENTS } from '../utils/contants.js';
+ import { NEW, NEW_PARENT, ROUTE_DOCUMENTS } from '../utils/contants.js';
  import { isNew } from '../utils/helper.js';
  import { getItem, removeItem, setItem } from '../utils/storage.js';
 
@@ -39,10 +39,10 @@ import Editor from './Editor.js';
              method: 'POST',
              body: JSON.stringify({
                 title: document.title,
-                parent: getItem(NEWPARENT, null),
+                parent: getItem(NEW_PARENT, null),
               }),
             });
-            removeItem(NEWPARENT);
+            removeItem(NEW_PARENT);
            history.replaceState(
              null,
              null,

--- a/src/components/DocumentEditPage/DocumentEditPage.js
+++ b/src/components/DocumentEditPage/DocumentEditPage.js
@@ -1,7 +1,7 @@
 import Editor from './Editor.js';
 
  import { request } from '../utils/api.js';
- import { NEW, ROUTE_DOCUMENTS } from '../utils/contants.js';
+ import { NEW, NEWPARENT, ROUTE_DOCUMENTS } from '../utils/contants.js';
  import { isNew } from '../utils/helper.js';
  import { getItem, removeItem, setItem } from '../utils/storage.js';
 
@@ -37,8 +37,12 @@ import Editor from './Editor.js';
          if (this.state.documentId === NEW) {
            const createdDocument = await request(ROUTE_DOCUMENTS, {
              method: 'POST',
-             body: JSON.stringify(document),
-           });
+             body: JSON.stringify({
+                title: document.title,
+                parent: getItem(NEWPARENT, null),
+              }),
+            });
+            removeItem(NEWPARENT);
            history.replaceState(
              null,
              null,

--- a/src/components/DocumentEditPage/DocumentFooter.js
+++ b/src/components/DocumentEditPage/DocumentFooter.js
@@ -1,0 +1,46 @@
+import { CLASS_NAME } from '../../utils/constants.js';
+import { push } from '../../utils/router.js';
+import { generateRouteDocuments, generateTitle } from '../../utils/helper.js';
+
+export default function DocumentFooter({ $target, initialState }) {
+  const $footer = document.createElement('footer');
+  $footer.className = CLASS_NAME.DOCUMENT_FOOTER;
+
+  $target.appendChild($footer);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = { ...this.state, ...nextState };
+    this.render();
+  };
+
+  this.render = () => {
+    if (!this.state.document || !this.state.document.documents) return;
+
+    const { documents } = this.state.document;
+
+    $footer.innerHTML = `
+      <div class="${CLASS_NAME.TITLES}">
+        ${documents
+          .map(
+            ({ id, title }) =>
+              `<p data-id="${id}" class="${CLASS_NAME.TITLE}">${generateTitle(
+                title
+              )}</p>`
+          )
+          .join('')}
+      </div>
+    `;
+  };
+
+  $footer.addEventListener('click', (e) => {
+    const $title = e.target.closest(`.${CLASS_NAME.TITLE}`);
+    if (!$title) return;
+
+    const { id } = $title.dataset;
+    push(generateRouteDocuments(parseInt(id)));
+  });
+
+  this.render();
+}

--- a/src/components/DocumentEditPage/DocumentHeader.js
+++ b/src/components/DocumentEditPage/DocumentHeader.js
@@ -1,0 +1,41 @@
+import { CLASS_NAME } from '../../utils/constants.js';
+import { generateTitle } from '../../utils/helper.js';
+
+export default function DocumentHeader({ $target, initialState, onDelete }) {
+  const $header = document.createElement('header');
+  $header.className = CLASS_NAME.DOCUMENT_HEADER;
+
+  $target.appendChild($header);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = { ...this.state, ...nextState };
+    this.render();
+  };
+
+  this.render = () => {
+    const { title } = this.state.document;
+
+    $header.innerHTML = `
+      <div>
+        <span class="${CLASS_NAME.TITLE}">${generateTitle(title)}</span>
+      </div>
+      <div class="${CLASS_NAME.BUTTONS}">
+        <button class="${CLASS_NAME.DELETE}" type="button">
+            <i class="fa-regular fa-trash-can ${CLASS_NAME.DELETE}"></i>
+        </button>
+      </div>
+    `;
+  };
+
+  $header.addEventListener('click', (e) => {
+    const { target } = e;
+
+    if (target.classList.contains(CLASS_NAME.DELETE)) {
+      onDelete(this.state.documentId,this.state.documentId);
+    }
+  });
+
+  this.render();
+}

--- a/src/components/DocumentEditPage/Editor.js
+++ b/src/components/DocumentEditPage/Editor.js
@@ -1,4 +1,5 @@
 import { isNew } from '../utils/helper.js';
+import { UNTITLED } from '../utils/contants.js';
 
  export default function Editor({
    $target,
@@ -10,7 +11,7 @@ import { isNew } from '../utils/helper.js';
    const $editor = document.createElement('div');
 
    $editor.innerHTML = `
-       <input type="text" name="title" style="width: 600px;" placeholder="untitled"/>
+   <input type="text" name="title" style="width: 600px;" placeholder="${UNTITLED}"/>
        <textarea name="content" style="width: 600px; height: 400px;" placeholder="Type '/' for commands"</textarea>
    `;
 

--- a/src/components/DocumentEditPage/Editor.js
+++ b/src/components/DocumentEditPage/Editor.js
@@ -1,48 +1,51 @@
-import { isNew } from '../utils/helper.js';
-import { UNTITLED } from '../utils/contants.js';
+import { isNew, setDocumentTitle } from '../../utils/helper.js';
+import { MESSAGE, TEXT } from '../../utils/constants.js';
 
- export default function Editor({
-   $target,
-   initialState = { title: '', content: '' },
-   onEditing,
- }) {
-   isNew(new.target);
+export default function Editor({
+  $target,
+  initialState = { title: '', content: '' },
+  onEdit,
+}) {
+  isNew(new.target);
 
-   const $editor = document.createElement('div');
+  const $editor = document.createElement('div');
+  $editor.className = 'editor';
 
-   $editor.innerHTML = `
-   <input type="text" name="title" style="width: 600px;" placeholder="${UNTITLED}"/>
-       <textarea name="content" style="width: 600px; height: 400px;" placeholder="Type '/' for commands"</textarea>
-   `;
+  $editor.innerHTML = `
+      <input type="text" name="title" class="title" placeholder="${TEXT.UNTITLED}" autofocus/>
+      <textarea name="content" class="content" placeholder="${MESSAGE.WRITE_CONTENT}"></textarea>
+  `;
 
-   $target.appendChild($editor);
+  $target.appendChild($editor);
 
-   this.state = initialState;
+  this.state = initialState;
 
-   this.setState = (nextState) => {
-     this.state = nextState;
-     this.render();
-   };
+  this.setState = (nextState) => {
+    this.state = { ...this.state, ...nextState };
+    this.render();
+  };
 
-   this.render = () => {
-     const { title, content } = this.state;
+  this.render = () => {
+    const { title, content } = this.state;
 
-     $editor.querySelector('[name=title]').value = title;
-     $editor.querySelector('[name=content]').value = content;
-   };
+    $editor.querySelector('[name=title]').value = title;
+    $editor.querySelector('[name=content]').value = content;
 
-   this.render();
+    setDocumentTitle(title);
+  };
 
-   $editor.addEventListener('keyup', (e) => {
-     const { target } = e;
+  this.render();
 
-     const name = target.getAttribute('name');
+  $editor.addEventListener('keyup', (e) => {
+    const { target } = e;
 
-     if (this.state[name] !== undefined) {
-       const nextState = { ...this.state, [name]: target.value };
+    const name = target.getAttribute('name');
 
-       this.setState(nextState);
-       onEditing(this.state);
-     }
-   });
- }
+    if (this.state[name] !== undefined) {
+      const nextState = { ...this.state, [name]: target.value };
+
+      this.setState(nextState);
+      onEdit(this.state);
+    }
+  });
+}

--- a/src/components/DocumentEditPage/Editor.js
+++ b/src/components/DocumentEditPage/Editor.js
@@ -1,0 +1,47 @@
+import { isNew } from '../utils/helper.js';
+
+ export default function Editor({
+   $target,
+   initialState = { title: '', content: '' },
+   onEditing,
+ }) {
+   isNew(new.target);
+
+   const $editor = document.createElement('div');
+
+   $editor.innerHTML = `
+       <input type="text" name="title" style="width: 600px;" placeholder="untitled"/>
+       <textarea name="content" style="width: 600px; height: 400px;" placeholder="Type '/' for commands"</textarea>
+   `;
+
+   $target.appendChild($editor);
+
+   this.state = initialState;
+
+   this.setState = (nextState) => {
+     this.state = nextState;
+     this.render();
+   };
+
+   this.render = () => {
+     const { title, content } = this.state;
+
+     $editor.querySelector('[name=title]').value = title;
+     $editor.querySelector('[name=content]').value = content;
+   };
+
+   this.render();
+
+   $editor.addEventListener('keyup', (e) => {
+     const { target } = e;
+
+     const name = target.getAttribute('name');
+
+     if (this.state[name] !== undefined) {
+       const nextState = { ...this.state, [name]: target.value };
+
+       this.setState(nextState);
+       onEditing(this.state);
+     }
+   });
+ }

--- a/src/components/Sidebar/DocumentAddButton.js
+++ b/src/components/Sidebar/DocumentAddButton.js
@@ -1,0 +1,28 @@
+import { CLASS_NAME, ID } from '../../utils/constants.js';
+
+export default function DocumentAddButton({ $target, initialState, onAdd }) {
+  const $button = document.createElement('div');
+
+  this.state = initialState;
+
+  const { position, text } = this.state;
+
+  $button.className = `${CLASS_NAME.DOCUMENT_ADD_BUTTON} ${position}`;
+
+  $button.innerHTML = `
+    <button type="button">
+      <i class="fa-solid fa-plus ${CLASS_NAME.ADD}"></i>
+    </button>
+    <p>${text}</p>
+  `;
+
+  this.render = () => {
+    $target.appendChild($button);
+  };
+
+  $button.addEventListener('click', () => {
+    onAdd(ID.NEW);
+  });
+
+  this.render();
+}

--- a/src/components/Sidebar/DocumentList.js
+++ b/src/components/Sidebar/DocumentList.js
@@ -1,0 +1,60 @@
+import { push } from '../utils/router.js';
+ import { NEW, ROUTE_DOCUMENTS } from '../utils/contants.js';
+ import { isNew } from '../utils/helper.js';
+
+ const DOCUMENT_ITEM = 'document-item';
+ const ADD = 'add';
+
+ export default function DocumentList({ $target, initialState }) {
+   isNew(new.target);
+
+   const $documentList = document.createElement('div');
+   $target.appendChild($documentList);
+
+   this.state = initialState;
+
+   this.setState = (nextState) => {
+     this.state = nextState;
+     this.render();
+   };
+
+   const renderDocuments = (nextDocuments) => `
+       <ul>
+         ${nextDocuments
+           .map(
+             ({ id, title, documents }) => `
+               <li data-id="${id}" class="${DOCUMENT_ITEM}">
+                 ${title}
+                 <button class="${ADD}" type="button">+</button>
+               </li>
+               ${
+                 documents.length
+                   ? renderDocuments(documents)
+                   : 'No pages inside'
+               }
+             `
+           )
+           .join('')}
+       </ul>
+     `;
+
+   this.render = () => {
+     if (this.state.length > 0) {
+       $documentList.innerHTML = renderDocuments(this.state);
+     }
+   };
+
+   $documentList.addEventListener('click', (e) => {
+     const $li = e.target.closest('li');
+     if (!$li) return;
+
+     const { id } = $li.dataset;
+     if (e.target.className === DOCUMENT_ITEM) {
+       push(`${ROUTE_DOCUMENTS}/${id}`);
+     } else if (e.target.className === ADD) {
+       push(`${ROUTE_DOCUMENTS}/${NEW}`);
+     }
+   });
+
+   this.render();
+ }

--- a/src/components/Sidebar/DocumentList.js
+++ b/src/components/Sidebar/DocumentList.js
@@ -1,68 +1,175 @@
-import { push } from '../utils/router.js';
-import { NEW, ROUTE_DOCUMENTS, UNTITLED } from '../utils/contants.js';
+import DocumentAddButton from './DocumentAddButton.js';
+import { push } from '../../utils/router.js';
+import { CLASS_NAME, KEY, TEXT } from '../../utils/constants.js';
 import {
-   NEW,
-   NEWPARENT,
-   ROUTE_DOCUMENTS,
-   UNTITLED,
-} from '../utils/contants.js';
-import { isNew } from '../utils/helper.js';
-import { setItem } from '../utils/storage.js';
+  isNew,
+  generateTitle,
+  generateTextIndent,
+  generateRouteDocuments,
+} from '../../utils/helper.js';
+import { getStorageItem, setStorageItem } from '../../utils/storage.js';
 
-const DOCUMENT_ITEM = 'document-item';
-const ADD = 'add';
 
-export default function DocumentList({ $target, initialState }) {
-   isNew(new.target);
+export default function DocumentList({
+  $target,
+  initialState,
+  onAdd,
+  onDelete,
+}) {
+  isNew(new.target);
 
-   const $documentList = document.createElement('div');
-   $target.appendChild($documentList);
+  const $documentList = document.createElement('div');
+  $documentList.className = CLASS_NAME.DOCUMENT_LIST;
+  $target.appendChild($documentList);
 
-   this.state = initialState;
+  this.state = initialState;
 
-   this.setState = (nextState) => {
-     this.state = nextState;
-     this.render();
-   };
+  this.setState = (nextState) => {
+    this.state = { ...this.state, ...nextState };
+    this.render();
+  };
 
-   const renderDocuments = (nextDocuments) => `
-       <ul>
-         ${nextDocuments
-           .map(
-             ({ id, title, documents }) => `
-               <li data-id="${id}" class="${DOCUMENT_ITEM}">
-                 ${title.length > 0 ? title : UNTITLED}
-                 <button class="${ADD}" type="button">+</button>
-               </li>
-               ${
-                 documents.length
-                   ? renderDocuments(documents)
-                   : 'No pages inside'
-               }
-             `
-           )
-           .join('')}
-       </ul>
-     `;
+    // 펼치기/접기 버튼 렌더링
+  let isBlock = false; //문서 닫힌 상태
 
-   this.render = () => {
-     if (this.state.length > 0) {
-       $documentList.innerHTML = renderDocuments(this.state);
-     }
-   };
+  const renderButton = (id) => {
+    const openedItems = getStorageItem(KEY.OPENED_ITEMS, []);
+    isBlock = openedItems.includes(id);
+    return `
+      <button class="${CLASS_NAME.TOGGLE} ${
+      isBlock ? CLASS_NAME.OPEN : ''
+    }" type="button">
+        <i class="${CLASS_NAME.TOGGLE} ${
+      isBlock ? CLASS_NAME.OPEN : ''
+    } fa-solid fa-angle-${isBlock ? 'down' : 'right'}"></i>
+      </button>
+    `;
+  };
 
-   $documentList.addEventListener('click', (e) => {
-     const $li = e.target.closest('li');
-     if (!$li) return;
+  //문서 목록, 하위 문서 렌더링(재귀적 호출)
+  const renderDocuments = (nextDocuments, depth) => `
+        ${nextDocuments
+          .map(
+            ({ id, title, documents }) => `
+            <ul>
+              <li 
+                data-id="${id}" 
+                class="${CLASS_NAME.DOCUMENT_ITEM} ${
+              id === this.state.selectedId ? CLASS_NAME.SELECTED : ''
+            }" 
+                style="padding-left: ${generateTextIndent(depth)}px">
+                ${renderButton(id)}
+                <p class="${CLASS_NAME.DOCUMENT_ITEM}">${generateTitle(
+              title
+            )}</p>
+                <div class="${CLASS_NAME.BUTTONS}">
+                  <button class="${CLASS_NAME.DELETE}" type="button">
+                    <i class="fa-regular fa-trash-can ${CLASS_NAME.DELETE}"></i>
+                  </button>
+                  <button class="${CLASS_NAME.ADD}" type="button">
+                    <i class="fa-solid fa-plus ${CLASS_NAME.ADD}"></i>
+                  </button>
+                </div>
+              </li>
+              ${
+                isBlock && documents.length
+                  ? renderDocuments(documents, depth + 2)
+                  : `<li 
+                      class="${CLASS_NAME.NOTSUBPAGES}" 
+                      style="
+                        padding-left: ${generateTextIndent(depth + 2)}px; 
+                        display: ${isBlock ? 'block' : 'none'};
+                      ">
+                      하위 페이지 없음
+                    </li>`
+              }
+              </ul>
+            `
+          )
+          .join('')}
+    `;
+  
+  // 문서 추가 버튼 렌더링
+  const documentAddButton = new DocumentAddButton({
+    $target: $documentList,
+    initialState: {
+      position: CLASS_NAME.DOCUMENT_LIST_BOTTOM,
+      text: TEXT.ADD_PAGE,
+    },
+    onAdd,
+  });
 
-     const { id } = $li.dataset;
-     if (e.target.className === DOCUMENT_ITEM) {
-       push(`${ROUTE_DOCUMENTS}/${id}`);
-     } else if (e.target.className === ADD) {
-        setItem(NEWPARENT, id); 
-       push(`${ROUTE_DOCUMENTS}/${NEW}`);
-     }
-   });
+  this.render = () => {
+    const { documents } = this.state;
 
-   this.render();
- }
+    $documentList.innerHTML = `
+      ${documents.length > 0 ? renderDocuments(documents, 1) : ''}
+    `;
+
+    documentAddButton.render();
+  };
+
+  $documentList.addEventListener('click', (e) => {
+    const { target } = e;
+    const $li = target.closest('li');
+    if (!$li) return;
+
+    let { id } = $li.dataset;
+    id = parseInt(id);
+
+    if (target.classList.contains(CLASS_NAME.DOCUMENT_ITEM)) {
+      push(generateRouteDocuments(id));
+      this.render();
+    } else if (target.classList.contains(CLASS_NAME.ADD)) {
+      setStorageItem(KEY.NEW_PARENT, id);
+      onAdd(id);
+      toggleOpen(target, id);
+    } else if (target.classList.contains(CLASS_NAME.DELETE)) {
+      onDelete(this.state.selectedId, id);
+    }
+
+    if (target.classList.contains(CLASS_NAME.TOGGLE)) {
+      toggleOpen(target, id);
+    }
+  });
+
+  // 항목을 열거나 닫을 때 호출
+  const toggleOpen = (target, id) => {
+    const openedItems = getStorageItem(KEY.OPENED_ITEMS, []);
+
+    if (target.classList.contains(CLASS_NAME.OPEN)) {
+      const index = openedItems.indexOf(id);
+      setStorageItem(KEY.OPENED_ITEMS, [
+        ...openedItems.slice(0, index),
+        ...openedItems.slice(index + 1),
+      ]);
+      target.classList.toggle(CLASS_NAME.OPEN);
+    } else {
+      if (openedItems.indexOf(id) > -1) return;
+      setStorageItem(KEY.OPENED_ITEMS, [...openedItems, id]);
+      target.classList.toggle(CLASS_NAME.OPEN);
+    }
+
+    this.render();
+  };
+
+  //마우스 이벤트에 따라 버튼 블록 토글
+  const toggleButtonBlock = (e) => {
+    const $li = e.target.closest('li');
+    if (!$li) return;
+
+    for (const element of $li.children) {
+      if (
+        element.classList.contains(CLASS_NAME.BUTTONS) ||
+        element.classList.contains(CLASS_NAME.DOCUMENT_ITEM)
+      ) {
+        element.classList.toggle('block');
+      }
+    }
+  };
+
+  $documentList.addEventListener('mouseover', toggleButtonBlock);
+  $documentList.addEventListener('mouseout', toggleButtonBlock);
+
+  this.render();
+}

--- a/src/components/Sidebar/DocumentList.js
+++ b/src/components/Sidebar/DocumentList.js
@@ -1,11 +1,18 @@
 import { push } from '../utils/router.js';
- import { NEW, ROUTE_DOCUMENTS } from '../utils/contants.js';
- import { isNew } from '../utils/helper.js';
+import { NEW, ROUTE_DOCUMENTS, UNTITLED } from '../utils/contants.js';
+import {
+   NEW,
+   NEWPARENT,
+   ROUTE_DOCUMENTS,
+   UNTITLED,
+} from '../utils/contants.js';
+import { isNew } from '../utils/helper.js';
+import { setItem } from '../utils/storage.js';
 
- const DOCUMENT_ITEM = 'document-item';
- const ADD = 'add';
+const DOCUMENT_ITEM = 'document-item';
+const ADD = 'add';
 
- export default function DocumentList({ $target, initialState }) {
+export default function DocumentList({ $target, initialState }) {
    isNew(new.target);
 
    const $documentList = document.createElement('div');
@@ -24,7 +31,7 @@ import { push } from '../utils/router.js';
            .map(
              ({ id, title, documents }) => `
                <li data-id="${id}" class="${DOCUMENT_ITEM}">
-                 ${title}
+                 ${title.length > 0 ? title : UNTITLED}
                  <button class="${ADD}" type="button">+</button>
                </li>
                ${
@@ -52,6 +59,7 @@ import { push } from '../utils/router.js';
      if (e.target.className === DOCUMENT_ITEM) {
        push(`${ROUTE_DOCUMENTS}/${id}`);
      } else if (e.target.className === ADD) {
+        setItem(NEWPARENT, id); 
        push(`${ROUTE_DOCUMENTS}/${NEW}`);
      }
    });

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,0 +1,24 @@
+import DocumentList from './DocumentList.js';
+import { request } from '../utils/api.js';
+import { ROUTE_DOCUMENTS } from '../utils/contants.js';
+import { isNew } from '../utils/helper.js';
+
+export default function Sidebar({ $target }) {
+   isNew(new.target);
+
+   const $sidebar = document.createElement('div');
+
+   $target.appendChild($sidebar);
+
+   const documentList = new DocumentList({
+     $target: $sidebar,
+     initialState: [],
+   });
+
+   this.render = async () => {
+     const documents = await request(ROUTE_DOCUMENTS);
+     documentList.setState(documents);
+   };
+
+   this.render();
+}

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,24 +1,60 @@
 import DocumentList from './DocumentList.js';
-import { request } from '../utils/api.js';
-import { ROUTE_DOCUMENTS } from '../utils/contants.js';
-import { isNew } from '../utils/helper.js';
+import DocumentAddButton from './DocumentAddButton.js';
+import SidebarHeader from './SidebarHeader.js';
 
-export default function Sidebar({ $target }) {
-   isNew(new.target);
+import { fetchDocuments } from '../../utils/api.js';
+import { isNew } from '../../utils/helper.js';
+import { CLASS_NAME, TEXT } from '../../utils/constants.js';
 
-   const $sidebar = document.createElement('div');
+export default function Sidebar({ $target, initialState, onAdd, onDelete }) {
+  isNew(new.target);
 
-   $target.appendChild($sidebar);
+  const $sidebar = document.createElement('div');
+  $sidebar.className = CLASS_NAME.SIDEBAR;
 
-   const documentList = new DocumentList({
-     $target: $sidebar,
-     initialState: [],
-   });
+  $target.appendChild($sidebar);
 
-   this.render = async () => {
-     const documents = await request(ROUTE_DOCUMENTS);
-     documentList.setState(documents);
-   };
+  this.state = initialState;
 
-   this.render();
+  this.setState = (nextState) => {
+    this.state = { ...this.state, ...nextState };
+    this.render();
+  };
+
+  new SidebarHeader({
+    $target: $sidebar,
+    initialState: {
+      workspaceName: '🎀 Kitty Notion',
+    },
+  });
+
+  const documentList = new DocumentList({
+    $target: $sidebar,
+    initialState: {
+      documents: [],
+      selectedId: this.state.selectedId,
+    },
+    onAdd,
+    onDelete,
+  });
+
+  const documentAddButton = new DocumentAddButton({
+    $target: $sidebar,
+    initialState: {
+      position: CLASS_NAME.SIDEBAR_BOTTOM,
+      text: TEXT.NEW_PAGE,
+    },
+    onAdd,
+  });
+
+  this.render = async () => {
+    const documents = await fetchDocuments(null);
+    documentList.setState({
+      documents,
+      selectedId: this.state.selectedId,
+    });
+    documentAddButton.render();
+  };
+
+  this.render();
 }

--- a/src/components/Sidebar/SidebarHeader.js
+++ b/src/components/Sidebar/SidebarHeader.js
@@ -1,0 +1,17 @@
+import { CLASS_NAME } from '../../utils/constants.js';
+
+export default function SidebarHeader({ $target, initialState }) {
+  const $header = document.createElement('div');
+  $header.className = CLASS_NAME.SIDEBAR_HEADER;
+  $target.appendChild($header);
+
+  this.state = initialState;
+
+  this.render = () => {
+    $header.innerHTML = `
+      <p>${this.state.workspaceName}</p>
+    `;
+  };
+
+  this.render();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,5 @@
+import App from './components/App.js';
+
+const $target = document.querySelector('#app');
+
+new App({ $target });

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,0 +1,129 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: '';
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -58,7 +58,7 @@ button {
 
 .document-list {
   overflow: auto;
-  height: 87.5%;
+  height: 70.5%;
 }
 
 .document-list li {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,0 +1,254 @@
+@import "reset.css";
+
+html,
+body {
+  position: relative;
+  height: 100vh;
+  overflow: hidden;
+}
+
+main {
+  display: flex;
+  width: 100vw;
+  height: 100%;
+  color: #37352f;
+  line-height: 1.5;
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Helvetica, 'Apple Color Emoji', Arial, sans-serif, 'Segoe UI Emoji',
+    'Segoe UI Symbol';
+}
+
+button {
+  border: transparent;
+  border-radius: 5px;
+  background: none;
+  cursor: pointer;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 230px;
+  height: 100%;
+  color: rgba(25, 23, 17, 0.6);
+  font-weight: 500;
+  font-size: 14px;
+  background: #fff2fa;
+  box-shadow: rgba(162, 83, 83, 0.02) -1px 0px 0px 0px inset;
+}
+
+.sidebar button {
+  color: #a3a29d;
+  padding: 1px 3px;
+}
+
+.sidebar button.add,
+.sidebar button.delete {
+  color: inherit;
+}
+
+.sidebar-header {
+  display: flex;
+  color: #37352f;
+  margin: 15px 0;
+  padding-left: 15px;
+  cursor: default;
+  font-size: 18px;
+}
+
+.document-list {
+  overflow: auto;
+  height: 87.5%;
+}
+
+.document-list li {
+  display: flex;
+  margin: 2px;
+  padding: 3px 5px;
+  border-radius: 3px;
+}
+.document-list li:not(.no-subpages) {
+  cursor: pointer;
+}
+.document-list li:not(.no-subpages):hover {
+  background-color: #ffe2f4;
+}
+.document-list li:not(.no-subpages):active {
+  background-color: #e9d4e1;
+}
+
+.document-list li.selected {
+  background-color: #ffffff;
+}
+
+.document-list li.selected p {
+  font-weight: 600;
+}
+
+.document-list p.document-item {
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 4px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.document-list p.document-item.block {
+  width: calc(100% - 75px);
+}
+
+.document-list .no-subpages {
+  font-weight: 400;
+  color: #989893;
+  cursor: default;
+}
+
+.document-list button:hover {
+  background-color: #dededd;
+}
+
+.document-list .buttons {
+  display: none;
+}
+
+.document-list .buttons.block {
+  display: block;
+  float: left;
+}
+
+.document-add-button.document-list-bottom {
+  display: flex;
+  padding: 5px 0;
+  cursor: pointer;
+}
+
+.document-add-button.document-list-bottom button {
+  color: inherit;
+  margin: 0 10px;
+}
+
+.document-add-button.sidebar-bottom {
+  display: inline-flex;
+  position: fixed;
+  bottom: 0;
+  width: inherit;
+  padding: 12px 0;
+  border-top: 1.5px solid #ededec;
+  background-color: inherit;
+  cursor: pointer;
+}
+
+.document-add-button.document-list-bottom:hover,
+.document-add-button.sidebar-bottom:hover {
+  background-color: #ffe2f4;
+}
+
+.document-add-button.sidebar-bottom button {
+  margin: 0 10px;
+}
+
+.document-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin-top: 12px;
+}
+
+.document-header .title {
+  max-width: 80%;
+  margin-left: 15px;
+  padding: 3px 5px;
+  font-size: 14px;
+  border-radius: 5px;
+  cursor: default;
+}
+
+.document-header .buttons {
+  padding-right: 20px;
+}
+
+.document-header button {
+  padding: 5px;
+}
+.document-header button:hover {
+  background-color: #efefef;
+  padding: 5px;
+}
+
+.document-edit-page {
+  width: calc(100vw - 230px);
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.editor {
+  width: 75%;
+  height: 92%;
+  margin: 50px;
+  background: #ffffff;
+  caret-color: #37352f;
+}
+
+.editor .title,
+.editor .content {
+  width: 100%;
+  padding: 10px;
+  color: inherit;
+  font-family: inherit;
+  border: none;
+  outline: none;
+}
+
+.editor .title {
+  font-size: 40px;
+  font-weight: 700;
+  overflow: hidden;
+  resize: none;
+}
+.editor .title::placeholder {
+  color: #e1e1e0;
+}
+
+.editor .content {
+  height: 85%;
+  font-size: 16px;
+  resize: none;
+  line-height: 1.8rem;
+}
+.editor .content::placeholder {
+  color: #9c9c98;
+}
+
+.document-footer {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 15px;
+}
+
+.document-footer .titles {
+  display: flex;
+  flex-wrap: wrap;
+
+}
+
+.document-footer .title {
+  border-radius: 20px;
+  border: 1px solid #efefef;
+  padding: 5px 12px;
+  margin-left: 15px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  box-shadow: 0px 1px 0.5px 0.5px #efefef;
+  cursor: pointer;
+  
+}
+.document-footer .title:hover {
+  background-color: #fbfbfa;
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -19,3 +19,9 @@ export const request = async (url, options = {}) => {
     console.error(e);
   }
 };
+
+export const fetchDocuments = async (documentId, options) =>
+  request(
+    `${API_END_POINT}/documents${documentId ? `/${documentId}` : ''}`,
+    options
+  );

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,21 @@
+export const API_END_POINT = 'https://kdt-frontend.programmers.co.kr'
+
+export const request = async (url, options = {}) => {
+  try {
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        'Content-type': 'application/json',
+        'x-username': 'kitty',
+      },
+    });
+
+    if (res.ok) {
+      return await res.json();
+    }
+
+    throw new Error('요청에 실패했습니다.');
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -25,3 +25,24 @@ export const TEXT = {
     UNTITLED: '제목 없음',
 };
   
+export const CLASS_NAME = {
+    ADD: 'add',
+    BUTTONS: 'buttons',
+    DELETE: 'delete',
+    DOCUMENT_ADD_BUTTON: 'document-add-button',
+    DOCUMENT_EDIT_PAGE: 'document-edit-page',
+    DOCUMENT_FOOTER: 'document-footer',
+    DOCUMENT_HEADER: 'document-header',
+    DOCUMENT_ITEM: 'document-item',
+    DOCUMENT_LIST: 'document-list',
+    DOCUMENT_LIST_BOTTOM: 'document-list-bottom',
+    NOTSUBPAGES: 'no-subpages',
+    OPEN: 'open',
+    SELECTED: 'selected',
+    SIDEBAR: 'sidebar',
+    SIDEBAR_HEADER: 'sidebar-header',
+    SIDEBAR_BOTTOM: 'sidebar-bottom',
+    TITLES: 'titles',
+    TITLE: 'title',
+    TOGGLE: 'toggle',
+  };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,16 @@
 export const ROUTE_DOCUMENTS = '/documents';
 export const NEW = 'new';
 
+export const ID = {
+    DEFAULT_DOCUMENT: 108986,
+    NEW: 'new',
+};
+  
+export const KEY = {
+    OPENED_ITEMS: 'opened-items',
+    NEW_PARENT: 'new-parent',
+};
+
 export const MESSAGE = {
     DO_NOT_DELETE_FIRST_PAGE: '첫 페이지는 지우지 말아주세요',
     DELETE_PAGE: '페이지를 삭제하시겠습니까?',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,2 +1,17 @@
 export const ROUTE_DOCUMENTS = '/documents';
- export const NEW = 'new';
+export const NEW = 'new';
+
+export const MESSAGE = {
+    DO_NOT_DELETE_FIRST_PAGE: '첫 페이지는 지우지 말아주세요',
+    DELETE_PAGE: '페이지를 삭제하시겠습니까?',
+    NOT_NEW_INSTANCE: 'new 없이 호출됨',
+    REDIRECT: '존재하지 않는 페이지입니다. 첫 페이지로 이동합니다.',
+    WRITE_CONTENT: '내용을 입력하세요',
+};
+
+export const TEXT = {
+    ADD_PAGE: '페이지 추가',
+    NEW_PAGE: '새 페이지',
+    UNTITLED: '제목 없음',
+};
+  

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,2 @@
+export const ROUTE_DOCUMENTS = '/documents';
+ export const NEW = 'new';

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,0 +1,9 @@
+export const isNew = (isNew) => {
+    try {
+      if (!isNew) {
+        throw new Error('new 없이 호출됨');
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,9 +1,27 @@
+import { MESSAGE, TEXT } from './constants.js';
+
 export const isNew = (isNew) => {
-    try {
-      if (!isNew) {
-        throw new Error('new 없이 호출됨');
-      }
-    } catch (e) {
-      console.error(e);
+  try {
+    if (!isNew) {
+      throw new Error(MESSAGE.NOT_NEW_INSTANCE);
     }
-  };
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+export const generateTitle = (title) => {
+  if (typeof title === 'string') {
+    return title.length > 0 ? title : TEXT.UNTITLED;
+  }
+};
+
+export const setDocumentTitle = (title) => {
+  if (typeof title === 'string') {
+    document.title = generateTitle(title);
+  }
+};
+
+export const generateTextIndent = (depth) => 12 * depth;
+
+export const generateRouteDocuments = (id) => `/documents/${id}`;

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,0 +1,22 @@
+const ROUTE_CHANGE_EVENT_NAME = 'route-change';
+
+export const initRouter = (onRoute) => {
+  window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
+    const { nextUrl } = e.detail;
+
+    if (nextUrl) {
+      history.pushState(null, null, nextUrl);
+      onRoute();
+    }
+  });
+};
+
+export const push = (nextUrl) => {
+  window.dispatchEvent(
+    new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
+      detail: {
+        nextUrl,
+      },
+    })
+  );
+};

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,18 @@
+const storage = window.localStorage;
+
+export const getStorageItem = (key, defaultValue) => {
+  try {
+    const storedValue = storage.getItem(key);
+    return storedValue ? JSON.parse(storedValue) : defaultValue;
+  } catch (e) {
+    return defaultValue;
+  }
+};
+
+export const setStorageItem = (key, value) => {
+  storage.setItem(key, JSON.stringify(value));
+};
+
+export const removeStorageItem = (key) => {
+  storage.removeItem(key);
+};


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
바닐라 JS만을 이용해 노션을 클로닝합니다.
<img width="80%" alt="kittynotion" src="https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/99376069/db31c46c-0660-4d35-842b-fc128d652640">


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
기본 요구 사항
☑︎ 글 단위를 Document라고 합니다. Document는 Document 여러개를 포함할 수 있습니다.
☑︎ 화면 좌측에 Root Documents를 불러오는 API를 통해 루트 Documents를 렌더링합니다.
   ☑︎ Root Document를 클릭하면 오른쪽 편집기 영역에 해당 Document의 Content를 렌더링합니다.
   ☑︎ 해당 Root Document에 하위 Document가 있는 경우, 해당 Document 아래에 트리 형태로 렌더링 합니다.
   ☑︎ Document Tree에서 각 Document 우측에는 + 버튼이 있습니다. 해당 버튼을 클릭하면, 클릭한 Document의 하위 Document로 새 Document를 생성하고 편집화면으로 넘깁니다.
☑︎ 편집기에는 기본적으로 저장 버튼이 없습니다. Document Save API를 이용해 지속적으로 서버에 저장되도록 합니다.
☑︎ History API를 이용해 SPA 형태로 만듭니다.
   ☑︎ 루트 URL 접속 시엔 별다른 편집기 선택이 안 된 상태입니다.
   ☑︎ /documents/{documentId} 로 접속시, 해당 Document 의 content를 불러와 편집기에 로딩합니다.

보너스 요구 사항
☐ 기본적으로 편집기는 textarea 기반으로 단순한 텍스트 편집기로 시작하되, 여력이 되면 div와 contentEditable을 조합해서 좀 더 Rich한 에디터를 만들어봅니다.
☑︎ 편집기 최하단에는 현재 편집 중인 Document의 하위 Document 링크를 렌더링하도록 추가합니다.
☐ 편집기 내에서 다른 Document name을 적은 경우, 자동으로 해당 Document의 편집 페이지로 이동하는 링크를 거는 기능을 추가합니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- 변수명, 함수명이 적절한지 궁금합니다.
- 마크다운이 적용되는 rich editor를 구현하려고 했는데 방법을 잘 모르겠고, 시간부족으로 구현하지 못했습니다. 팁이나 방법이 궁금합니다.