### PR TITLE
[Project1/김유경] Notion 클로닝 프로젝트

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>노션 클로닝</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css"
+    />
     <link href="/src/styles/index.css" rel="stylesheet" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>노션 클로닝</title>
+    <link href="/src/styles/index.css" rel="stylesheet" />
+</head>
+<body>
+    <main id="app"></main>    
+    <script src="/src/main.js" type="module"></script>
+</body>
+</html>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,7 @@
 import DocumentList from "./DocumentList.js";
 import DocumentEditSection from "./DocumentEditSection.js";
 import { request } from "../utils/api.js";
-import { initRouter, push } from "../utils/route.js";
+import { initRouter, replace } from "../utils/route.js";
 
 export default function App({ $target, initialState }) {
   this.state = initialState;
@@ -38,7 +38,7 @@ export default function App({ $target, initialState }) {
       await request(`/documents/${id}`, {
         method: "DELETE",
       });
-      push("/");
+      replace('/');
       fetchDocments();
     },
   });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -21,9 +21,8 @@ export default function App({ $target, initialState }) {
 
       documentList.setState({
         documentId,
-        documents
-      },);
-
+        documents,
+      });
     }
 
     this.render();
@@ -33,7 +32,7 @@ export default function App({ $target, initialState }) {
     $target,
     initialState: {
       selectedId: 0,
-      documents: this.state.documents
+      documents: this.state.documents,
     },
     onDocumentRemove: async (id) => {
       await request(`/documents/${id}`, {
@@ -101,4 +100,6 @@ export default function App({ $target, initialState }) {
   fetchDocments();
 
   initRouter(() => this.route());
+
+  window.addEventListener("popstate", () => this.route());
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -50,6 +50,14 @@ export default function App({ $target, initialState }) {
       documentId: this.state.documentId,
       document: this.state.selectedDocument,
     },
+    onCreateDocument: ({ document, documentId }) => {
+      this.setState({
+        ...this.state,
+        selectedDocument: document,
+        documentId: documentId,
+      });
+      fetchDocments();
+    },
   });
 
   this.route = () => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,15 +1,12 @@
 import DocumentList from "./DocumentList.js";
 import DocumentEditSection from "./DocumentEditSection.js";
 import { request } from "../utils/api.js";
-import { initRouter, push } from "../utils/route.js";
+import { initRouter } from "../utils/route.js";
 
 export default function App({ $target }) {
   const documentList = new DocumentList({
     $target,
     initialState: [],
-    onDocumentItemClick: (id) => {
-      push(`/document/${id}`);
-    },
   });
 
   const $editorSection = document.createElement("div");

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,7 +6,7 @@ import { initRouter, push } from "../utils/route.js";
 export default function App({ $target, initialState }) {
   this.state = initialState;
 
-  this.setState = async (nextState) => {
+  this.setState = (nextState) => {
     if (nextState.documentId !== this.state.documentId) {
       this.state = nextState;
       const { documentId, selectedDocument } = this.state;
@@ -44,11 +44,7 @@ export default function App({ $target, initialState }) {
   });
 
   const $editorSection = document.createElement("div");
-
-  this.render = () => {
-    $target.appendChild($editorSection);
-    $editorSection.setAttribute("class", "editor-page");
-  };
+  $editorSection.className = "editor-page";
 
   const documentEditSection = new DocumentEditSection({
     $target: $editorSection,
@@ -56,7 +52,7 @@ export default function App({ $target, initialState }) {
       documentId: this.state.documentId,
       document: this.state.selectedDocument,
     },
-    onCreateDocument: ({ document, documentId }) => {
+    onChangeDocument: ({ document, documentId }) => {
       this.setState({
         ...this.state,
         selectedDocument: document,
@@ -65,6 +61,10 @@ export default function App({ $target, initialState }) {
       fetchDocments();
     },
   });
+
+  this.render = () => {
+    $target.appendChild($editorSection);
+  };
 
   this.route = () => {
     const { pathname } = window.location;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -14,7 +14,7 @@ export default function App({ $target }) {
 
   const $editorSection = document.createElement("div");
   $target.appendChild($editorSection);
-  $editorSection.setAttribute("class", "editor-section");
+  $editorSection.setAttribute("class", "editor-page");
 
   const documentEditSection = new DocumentEditSection({
     $target: $editorSection,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,12 +1,19 @@
 import DocumentList from "./DocumentList.js";
 import DocumentEditSection from "./DocumentEditSection.js";
 import { request } from "../utils/api.js";
-import { initRouter } from "../utils/route.js";
+import { initRouter, push } from "../utils/route.js";
 
 export default function App({ $target }) {
   const documentList = new DocumentList({
     $target,
     initialState: [],
+    onDocumentRemove: async (id) => {
+      await request(`/documents/${id}`, {
+        method: "DELETE",
+      });
+      push("/");
+      fetchDocments();
+    },
   });
 
   const $editorSection = document.createElement("div");

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,0 +1,16 @@
+import DocumentList from "./DocumentList.js";
+import { request } from "../utils/api.js";
+
+export default function App({ $target }) {
+  const documentList = new DocumentList({
+    $target,
+    initialState: [],
+  });
+
+  const fetchDocments = async () => {
+    const documents = await request("/documents");
+    documentList.setState(documents);
+  };
+
+  fetchDocments();
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,11 +1,15 @@
 import DocumentList from "./DocumentList.js";
 import DocumentEditSection from "./DocumentEditSection.js";
 import { request } from "../utils/api.js";
+import { initRouter, push } from "../utils/route.js";
 
 export default function App({ $target }) {
   const documentList = new DocumentList({
     $target,
     initialState: [],
+    onDocumentItemClick: (id) => {
+      push(`/document/${id}`);
+    },
   });
 
   const $editorSection = document.createElement("div");
@@ -25,12 +29,11 @@ export default function App({ $target }) {
 
   this.route = () => {
     const { pathname } = window.location;
-
+    $editorSection.innerHTML = "";
     if (pathname === "/") {
       $editorSection.innerHTML = "<h1>아직 문서를 선택하지 않았습니다.</h1>";
     } else if (pathname.indexOf("/document/") === 0) {
       const [, , documentId] = pathname.split("/");
-
       documentEditSection.setState({
         documentId,
         document: {
@@ -49,4 +52,6 @@ export default function App({ $target }) {
   };
 
   fetchDocments();
+
+  initRouter(() => this.route());
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,15 +1,136 @@
 import DocumentList from "./DocumentList.js";
+import Editor from "./Editor.js";
 import { request } from "../utils/api.js";
+import { setItem, removeItem, getItem } from "../utils/storage.js";
 
-export default function App({ $target }) {
+export default function App({ $target, initialState }) {
   const documentList = new DocumentList({
     $target,
     initialState: [],
   });
 
+  const $editorSection = document.createElement("div");
+  $target.appendChild($editorSection);
+  $editorSection.setAttribute("class", "editor-section");
+
+  this.state = initialState;
+
+  let documentLocalSaveKey = `temp-post-${this.state.documentId}`;
+
+  this.setState = (nextState) => {
+    if (this.state.documentId !== nextState.documentId) {
+      this.state = nextState;
+      if (this.state.documentId === "new") {
+        documentLocalSaveKey = `temp-document-${this.state.document.id}`;
+
+        setItem(documentLocalSaveKey, {
+          ...this.state,
+          tempSaveDate: new Date(),
+        });
+      } else {
+        fetchDocument();
+      }
+    }
+
+    this.state = nextState;
+    documentLocalSaveKey = `temp-document-${this.state.document.id}`;
+
+    setItem(documentLocalSaveKey, {
+      ...this.state.document,
+      tempSaveDate: new Date(),
+    });
+
+    editor.setState(this.state.document);
+  };
+
+  let timer = null;
+
+  const editor = new Editor({
+    $target: $editorSection,
+    initialState: {
+      documentId: 0,
+      document: {
+        title: "",
+        content: "",
+      },
+    },
+    onEditing: (document) => {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+
+      documentLocalSaveKey = `temp-document-${document.id}`;
+
+      timer = setTimeout(async () => {
+        setItem(documentLocalSaveKey, {
+          ...document,
+          tempSaveDate: new Date(),
+        });
+
+        if (this.state.documentId === "new") {
+          const createDocument = await request("/documents", {
+            method: "POST",
+            body: JSON.stringify({
+              title: document.title,
+              parent: document.parent || null,
+            }),
+          });
+
+          history.replaceState(null, null, `/document/${createDocument.id}`);
+
+          removeItem(documentLocalSaveKey);
+          this.setState({
+            ...this.state,
+            document: createDocument,
+          });
+        } else {
+          await request(`/documents/${document.id}`, {
+            method: "PUT",
+            body: JSON.stringify({
+              title: document.title,
+              content: document.content,
+            }),
+          });
+          documentLocalSaveKey = `temp-document-${document.id}`;
+          removeItem(documentLocalSaveKey);
+        }
+      }, 1000);
+    },
+  });
+
   const fetchDocments = async () => {
     const documents = await request("/documents");
     documentList.setState(documents);
+  };
+
+  const fetchDocument = async () => {
+    const { documentId } = this.state;
+
+    if (documentId === "new") return;
+
+    const document = await request(`/documents/${documentId}`);
+
+    documentLocalSaveKey = `temp-document-${documentId}`;
+
+    const storedDocument = getItem(documentLocalSaveKey, {
+      title: "",
+      content: "",
+    });
+
+    const { tempSaveDate } = storedDocument;
+    if (tempSaveDate && tempSaveDate > document.updatedAt) {
+      if (confirm("저장안된 임시 데이터가 존재합니다. 불러올까요?")) {
+        this.setState({
+          ...this.state,
+          document: storedDocument,
+        });
+      }
+    }
+
+    this.setState({
+      documentId,
+      document,
+    });
   };
 
   fetchDocments();

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,9 +1,8 @@
 import DocumentList from "./DocumentList.js";
-import Editor from "./Editor.js";
+import DocumentEditSection from "./DocumentEditSection.js";
 import { request } from "../utils/api.js";
-import { setItem, removeItem, getItem } from "../utils/storage.js";
 
-export default function App({ $target, initialState }) {
+export default function App({ $target }) {
   const documentList = new DocumentList({
     $target,
     initialState: [],
@@ -13,39 +12,7 @@ export default function App({ $target, initialState }) {
   $target.appendChild($editorSection);
   $editorSection.setAttribute("class", "editor-section");
 
-  this.state = initialState;
-
-  let documentLocalSaveKey = `temp-post-${this.state.documentId}`;
-
-  this.setState = (nextState) => {
-    if (this.state.documentId !== nextState.documentId) {
-      this.state = nextState;
-      if (this.state.documentId === "new") {
-        documentLocalSaveKey = `temp-document-${this.state.document.id}`;
-
-        setItem(documentLocalSaveKey, {
-          ...this.state,
-          tempSaveDate: new Date(),
-        });
-      } else {
-        fetchDocument();
-      }
-    }
-
-    this.state = nextState;
-    documentLocalSaveKey = `temp-document-${this.state.document.id}`;
-
-    setItem(documentLocalSaveKey, {
-      ...this.state.document,
-      tempSaveDate: new Date(),
-    });
-
-    editor.setState(this.state.document);
-  };
-
-  let timer = null;
-
-  const editor = new Editor({
+  const documentEditSection = new DocumentEditSection({
     $target: $editorSection,
     initialState: {
       documentId: 0,
@@ -54,83 +21,31 @@ export default function App({ $target, initialState }) {
         content: "",
       },
     },
-    onEditing: (document) => {
-      if (timer !== null) {
-        clearTimeout(timer);
-      }
-
-      documentLocalSaveKey = `temp-document-${document.id}`;
-
-      timer = setTimeout(async () => {
-        setItem(documentLocalSaveKey, {
-          ...document,
-          tempSaveDate: new Date(),
-        });
-
-        if (this.state.documentId === "new") {
-          const createDocument = await request("/documents", {
-            method: "POST",
-            body: JSON.stringify({
-              title: document.title,
-              parent: document.parent || null,
-            }),
-          });
-
-          history.replaceState(null, null, `/document/${createDocument.id}`);
-
-          removeItem(documentLocalSaveKey);
-          this.setState({
-            ...this.state,
-            document: createDocument,
-          });
-        } else {
-          await request(`/documents/${document.id}`, {
-            method: "PUT",
-            body: JSON.stringify({
-              title: document.title,
-              content: document.content,
-            }),
-          });
-          documentLocalSaveKey = `temp-document-${document.id}`;
-          removeItem(documentLocalSaveKey);
-        }
-      }, 1000);
-    },
   });
+
+  this.route = () => {
+    const { pathname } = window.location;
+
+    if (pathname === "/") {
+      $editorSection.innerHTML = "<h1>아직 문서를 선택하지 않았습니다.</h1>";
+    } else if (pathname.indexOf("/document/") === 0) {
+      const [, , documentId] = pathname.split("/");
+
+      documentEditSection.setState({
+        documentId,
+        document: {
+          title: "",
+          content: "",
+        },
+      });
+    }
+  };
+
+  this.route();
 
   const fetchDocments = async () => {
     const documents = await request("/documents");
     documentList.setState(documents);
-  };
-
-  const fetchDocument = async () => {
-    const { documentId } = this.state;
-
-    if (documentId === "new") return;
-
-    const document = await request(`/documents/${documentId}`);
-
-    documentLocalSaveKey = `temp-document-${documentId}`;
-
-    const storedDocument = getItem(documentLocalSaveKey, {
-      title: "",
-      content: "",
-    });
-
-    const { tempSaveDate } = storedDocument;
-    if (tempSaveDate && tempSaveDate > document.updatedAt) {
-      if (confirm("저장안된 임시 데이터가 존재합니다. 불러올까요?")) {
-        this.setState({
-          ...this.state,
-          document: storedDocument,
-        });
-      }
-    }
-
-    this.setState({
-      documentId,
-      document,
-    });
   };
 
   fetchDocments();

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -17,9 +17,13 @@ export default function App({ $target, initialState }) {
       });
     } else {
       this.state = nextState;
-      const { documents } = this.state;
+      const { documentId, documents } = this.state;
 
-      documentList.setState(documents);
+      documentList.setState({
+        documentId,
+        documents
+      },);
+
     }
 
     this.render();
@@ -27,7 +31,10 @@ export default function App({ $target, initialState }) {
 
   const documentList = new DocumentList({
     $target,
-    initialState: this.state.documents,
+    initialState: {
+      selectedId: 0,
+      documents: this.state.documents
+    },
     onDocumentRemove: async (id) => {
       await request(`/documents/${id}`, {
         method: "DELETE",

--- a/src/components/DocumentEditSection.js
+++ b/src/components/DocumentEditSection.js
@@ -1,0 +1,123 @@
+import Editor from "./Editor.js";
+import { request } from "../utils/api.js";
+import { setItem, removeItem, getItem } from "../utils/storage.js";
+
+export default function DocumentEditSection({ $target, initialState }) {
+  const $section = document.createElement("div");
+  $target.appendChild($section);
+
+  this.state = initialState;
+
+  let documentLocalSaveKey = `temp-post-${this.state.documentId}`;
+
+  this.setState = (nextState) => {
+    if (this.state.documentId !== nextState.documentId) {
+      this.state = nextState;
+      if (this.state.documentId === "new") {
+        documentLocalSaveKey = `temp-document-${this.state.document.id}`;
+
+        setItem(documentLocalSaveKey, {
+          ...this.state,
+          tempSaveDate: new Date(),
+        });
+      } else {
+        fetchDocument();
+      }
+    }
+
+    this.state = nextState;
+    documentLocalSaveKey = `temp-document-${this.state.document.id}`;
+
+    setItem(documentLocalSaveKey, {
+      ...this.state.document,
+      tempSaveDate: new Date(),
+    });
+
+    editor.setState(this.state.document);
+  };
+
+  let timer = null;
+
+  const editor = new Editor({
+    $target: $section,
+    initialState: {
+      documentId: 0,
+      document: {
+        title: "",
+        content: "",
+      },
+    },
+    onEditing: (document) => {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+
+      documentLocalSaveKey = `temp-document-${document.id}`;
+
+      timer = setTimeout(async () => {
+        setItem(documentLocalSaveKey, {
+          ...document,
+          tempSaveDate: new Date(),
+        });
+
+        if (this.state.documentId === "new") {
+          const createDocument = await request("/documents", {
+            method: "POST",
+            body: JSON.stringify({
+              title: document.title,
+              parent: document.parent || null,
+            }),
+          });
+
+          history.replaceState(null, null, `/document/${createDocument.id}`);
+
+          removeItem(documentLocalSaveKey);
+          this.setState({
+            ...this.state,
+            document: createDocument,
+          });
+        } else {
+          await request(`/documents/${document.id}`, {
+            method: "PUT",
+            body: JSON.stringify({
+              title: document.title,
+              content: document.content,
+            }),
+          });
+          documentLocalSaveKey = `temp-document-${document.id}`;
+          removeItem(documentLocalSaveKey);
+        }
+      }, 1000);
+    },
+  });
+
+  const fetchDocument = async () => {
+    const { documentId } = this.state;
+
+    if (documentId === "new") return;
+
+    const document = await request(`/documents/${documentId}`);
+
+    documentLocalSaveKey = `temp-document-${documentId}`;
+
+    const storedDocument = getItem(documentLocalSaveKey, {
+      title: "",
+      content: "",
+    });
+
+    const { tempSaveDate } = storedDocument;
+    if (tempSaveDate && tempSaveDate > document.updatedAt) {
+      if (confirm("저장안된 임시 데이터가 존재합니다. 불러올까요?")) {
+        this.setState({
+          ...this.state,
+          document: storedDocument,
+        });
+      }
+    }
+
+    this.setState({
+      documentId,
+      document,
+    });
+  };
+}

--- a/src/components/DocumentEditSection.js
+++ b/src/components/DocumentEditSection.js
@@ -2,7 +2,11 @@ import Editor from "./Editor.js";
 import { request } from "../utils/api.js";
 import { setItem, removeItem, getItem } from "../utils/storage.js";
 
-export default function DocumentEditSection({ $target, initialState }) {
+export default function DocumentEditSection({
+  $target,
+  initialState,
+  onCreateDocument,
+}) {
   const $div = document.createElement("div");
 
   this.state = initialState;
@@ -60,7 +64,7 @@ export default function DocumentEditSection({ $target, initialState }) {
           });
           removeItem("temp-document-new");
 
-          this.setState({
+          onCreateDocument({
             documentId: createDocument.id,
             document: createDocument,
           });

--- a/src/components/DocumentEditSection.js
+++ b/src/components/DocumentEditSection.js
@@ -11,16 +11,11 @@ export default function DocumentEditSection({ $target, initialState }) {
 
   let timer = null;
 
-  const defaultValue = {
-    title: "",
-    content: "",
-  }
-
   const editor = new Editor({
     $target: $div,
     initialState: {
-      documentId: 0,
-      document: defaultValue
+      documentId: this.state.documentId,
+      document: this.state.document,
     },
     onEditing: (document) => {
       if (timer !== null) {
@@ -63,12 +58,12 @@ export default function DocumentEditSection({ $target, initialState }) {
             ...createDocument,
             tempSaveDate: new Date(),
           });
-          removeItem('temp-document-new');
+          removeItem("temp-document-new");
 
           this.setState({
             documentId: createDocument.id,
-            document: createDocument
-          })
+            document: createDocument,
+          });
         } else {
           await request(`/documents/${document.id}`, {
             method: "PUT",
@@ -85,24 +80,29 @@ export default function DocumentEditSection({ $target, initialState }) {
   });
 
   this.setState = async (nextState) => {
-    documentLocalSaveKey = `temp-document-${this.state.documentId || "new"}`;
     if (this.state.documentId !== nextState.documentId) {
       this.state = nextState;
+      documentLocalSaveKey = `temp-document-${this.state.documentId || "new"}`;
 
-      if (this.state.documentId === 'new') {
-        const storedDocument = getItem("temp-document-new", '');
-        
-        if (storedDocument !== '') {
+      if (this.state.documentId === "new") {
+        const storedDocument = getItem("temp-document-new", "");
+        const defaultValue = {
+          title: "",
+          content: "",
+        };
+
+        if (storedDocument !== "") {
           if (confirm("저장안된 임시 데이터가 존재합니다. 불러올까요?")) {
+            this.render();
             editor.setState(storedDocument);
           } else {
+            this.render();
             editor.setState(defaultValue);
           }
         } else {
           editor.setState(defaultValue);
         }
-      }
-      else {
+      } else {
         if (this.state.documentId !== "new") {
           await fetchDocument();
           return;
@@ -140,6 +140,7 @@ export default function DocumentEditSection({ $target, initialState }) {
           ...this.state,
           document: storedDocument,
         });
+        return;
       }
     }
 

--- a/src/components/DocumentEditSection.js
+++ b/src/components/DocumentEditSection.js
@@ -3,43 +3,16 @@ import { request } from "../utils/api.js";
 import { setItem, removeItem, getItem } from "../utils/storage.js";
 
 export default function DocumentEditSection({ $target, initialState }) {
-  const $section = document.createElement("div");
-  $target.appendChild($section);
+  const $div = document.createElement("div");
 
   this.state = initialState;
 
   let documentLocalSaveKey = `temp-post-${this.state.documentId}`;
 
-  this.setState = (nextState) => {
-    if (this.state.documentId !== nextState.documentId) {
-      this.state = nextState;
-      if (this.state.documentId === "new") {
-        documentLocalSaveKey = `temp-document-${this.state.document.id}`;
-
-        setItem(documentLocalSaveKey, {
-          ...this.state,
-          tempSaveDate: new Date(),
-        });
-      } else {
-        fetchDocument();
-      }
-    }
-
-    this.state = nextState;
-    documentLocalSaveKey = `temp-document-${this.state.document.id}`;
-
-    setItem(documentLocalSaveKey, {
-      ...this.state.document,
-      tempSaveDate: new Date(),
-    });
-
-    editor.setState(this.state.document);
-  };
-
   let timer = null;
 
   const editor = new Editor({
-    $target: $section,
+    $target: $div,
     initialState: {
       documentId: 0,
       document: {
@@ -90,6 +63,37 @@ export default function DocumentEditSection({ $target, initialState }) {
       }, 1000);
     },
   });
+
+  this.setState = (nextState) => {
+    if (this.state.documentId !== nextState.documentId) {
+      this.state = nextState;
+      if (this.state.documentId === "new") {
+        documentLocalSaveKey = `temp-document-${this.state.document.id}`;
+
+        setItem(documentLocalSaveKey, {
+          ...this.state,
+          tempSaveDate: new Date(),
+        });
+      } else {
+        fetchDocument();
+      }
+    }
+
+    this.state = nextState;
+    this.render();
+    documentLocalSaveKey = `temp-document-${this.state.document.id}`;
+
+    setItem(documentLocalSaveKey, {
+      ...this.state.document,
+      tempSaveDate: new Date(),
+    });
+
+    editor.setState(this.state.document);
+  };
+
+  this.render = () => {
+    $target.appendChild($div);
+  };
 
   const fetchDocument = async () => {
     const { documentId } = this.state;

--- a/src/components/DocumentEditSection.js
+++ b/src/components/DocumentEditSection.js
@@ -38,7 +38,7 @@ export default function DocumentEditSection({ $target, initialState }) {
             method: "POST",
             body: JSON.stringify({
               title: document.title,
-              parent: document.parent || null,
+              parent: document.parentId,
             }),
           });
 

--- a/src/components/DocumentEditSection.js
+++ b/src/components/DocumentEditSection.js
@@ -1,6 +1,7 @@
 import Editor from "./Editor.js";
 import { request } from "../utils/api.js";
 import { setItem, removeItem, getItem } from "../utils/storage.js";
+import { replace } from "../utils/route.js";
 
 export default function DocumentEditSection({
   $target,
@@ -50,7 +51,7 @@ export default function DocumentEditSection({
             }),
           });
 
-          history.replaceState(null, null, `/document/${createDocument.id}`);
+          replace(`/document/${createDocument.id}`, null);
 
           createDocument.content = getItem(
             documentLocalSaveKey,
@@ -135,7 +136,7 @@ export default function DocumentEditSection({
     if (documentId === "new") return;
 
     documentLocalSaveKey = `temp-document-${documentId}`;
-    
+
     const storedDocument = getItem(documentLocalSaveKey, defaultDocumentValue);
     const { tempSaveDate } = storedDocument;
 

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -1,0 +1,62 @@
+export default function DocumentList({$target, initialState}) {
+    const $document = document.createElement('div');
+    $target.appendChild($document);
+    
+    this.state = initialState;
+
+    this.setState = (nextState) => {
+        this.state = nextState;
+        this.render();
+    }
+
+    const documentPrint = (documents) => {
+        let htmlString = '';
+        documents.forEach(document => {
+            htmlString += `
+                <div class="documents-item" data-id="${document.id}">
+                    <span>${document.title}</span>
+                    <div class="documents-item fold">
+                        ${document.documents && document.documents.length !== 0 ? documentPrint(document.documents) : '<span class="end-document-item">하위 페이지 없음</span>'}
+                    </div>
+                </div>
+            `;
+        });
+
+        return htmlString;
+    }
+
+    this.render = () => {
+        if(this.state.length === 0) {
+            $document.innerHTML = '';
+            return;
+        }
+
+        $document.innerHTML = `
+            ${documentPrint(this.state)}
+        `;
+    }
+
+    this.render();
+
+    $document.addEventListener('click', (e) => {
+        const $documentItem = e.target.closest('.documents-item');
+
+        if($documentItem) {
+            const $child = $documentItem.children[1];
+
+            if($child) {
+                const isFolded = $child.classList.contains('fold');
+
+                if(isFolded) {
+                    $child.classList.remove('fold');
+                    $child.classList.add('show');
+                } else {
+                    $child.classList.remove('show');
+                    $child.classList.add('fold');
+                } 
+            }
+                    
+        }
+    })
+}
+

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -1,9 +1,9 @@
 import { push } from "../utils/route.js";
-import { request } from "../utils/api.js";
 
 export default function DocumentList({
   $target,
   initialState,
+  onDocumentRemove,
 }) {
   const $document = document.createElement("div");
   $document.setAttribute("class", "documents-container");
@@ -26,6 +26,7 @@ export default function DocumentList({
                 <button class="toggle">></button>
                 <span>${document.title}</span>
                 <button class="add-document">➕</button>
+                <button class="remove-document">❌</button>
             </div>
             <div class="documents-item fold">
                 ${
@@ -71,6 +72,8 @@ export default function DocumentList({
         $hideItem.classList.toggle("fold");
         $hideItem.classList.toggle("show");
       }
+    } else if (e.target.className === "remove-document") {
+      onDocumentRemove(id);
     } else if ($documentItem) {
       push(`/document/${id}`);
     }

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -20,10 +20,13 @@ export default function DocumentList({
   const documentPrint = (documents) => {
     let htmlString = "";
     documents.forEach((document) => {
-
       htmlString += `
         <div class="documents-item">
-            <div class="document-item-title-wrap ${document.id === parseInt(this.state.documentId) ? 'selected-document' : ''}" data-id="${document.id}">
+            <div class="document-item-title-wrap ${
+              document.id === parseInt(this.state.documentId)
+                ? "selected-document"
+                : ""
+            }" data-id="${document.id}">
                 <button class="toggle">
                   <i class="fas fa-chevron-right" style="color: #797979;"></i>
                 </button>
@@ -78,32 +81,42 @@ export default function DocumentList({
     const id = $documentItem ? $documentItem.dataset.id : null;
     const $button = e.target.closest("button");
 
-    if(e.target.className === 'add-document-wrap') {
+    if (e.target.className === "add-document-wrap") {
       push("/document/new");
       return;
     }
 
     if ($button) {
       const { className } = $button;
-      if (className === "add-document") {
-        let state = { parentId: id };
-        push("/document/new", state);
-      } else if (className === "toggle") {
-        const $hideItem = $documentItem.closest(".documents-item").children[1];
-        if ($hideItem) {
-          $hideItem.classList.toggle("fold");
-          $hideItem.classList.toggle("show");
-        }
-      } else if (className === "remove-document") {
-        onDocumentRemove(id);
+
+      switch (className) {
+        case "add-document":
+          push("/document/new", { parentId: id });
+          break;
+        case "toggle":
+          const $hideItem = $documentItem.closest(".documents-item").children[1];
+          if ($hideItem) {
+            $hideItem.classList.toggle("fold");
+            $hideItem.classList.toggle("show");
+          }
+          break;
+        case "remove-document":
+          onDocumentRemove(id);
+          break;
+        default:
+          break;
       }
-    } else if ($documentItem) {
-      const $title = $documentItem.querySelector('.document-item-title');
-      if($title) {
+
+      return;
+    }
+
+    if ($documentItem) {
+      const $title = $documentItem.querySelector(".document-item-title");
+      if ($title) {
         this.setState({
           ...this.state,
-          documentId: id
-        })
+          documentId: id,
+        });
       }
       push(`/document/${id}`);
     }

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -1,7 +1,9 @@
+import { push } from "../utils/route.js";
+import { request } from "../utils/api.js";
+
 export default function DocumentList({
   $target,
   initialState,
-  onDocumentItemClick,
 }) {
   const $document = document.createElement("div");
   $document.setAttribute("class", "documents-container");
@@ -19,10 +21,11 @@ export default function DocumentList({
     let htmlString = "";
     documents.forEach((document) => {
       htmlString += `
-        <div class="documents-item" data-id="${document.id}">
-            <div class="document-item-title-wrap">
+        <div class="documents-item">
+            <div class="document-item-title-wrap" data-id="${document.id}">
                 <button class="toggle">></button>
                 <span>${document.title}</span>
+                <button class="add-document">➕</button>
             </div>
             <div class="documents-item fold">
                 ${
@@ -39,40 +42,37 @@ export default function DocumentList({
   };
 
   this.render = () => {
+    $document.innerHTML = `
+        <button class="add-document">➕</button>
+        <div class="document-items"></div>
+    `;
+
     if (this.state.length === 0) {
-      $document.innerHTML += "";
       return;
     }
 
-    $document.innerHTML += `
-            ${documentPrint(this.state)}
-        `;
+    $document.querySelector(".document-items").innerHTML = `
+        ${documentPrint(this.state)}
+    `;
   };
 
   this.render();
 
   $document.addEventListener("click", (e) => {
-    const $documentItem = e.target.closest(".documents-item");
+    const $documentItem = e.target.closest(".document-item-title-wrap");
+    const id = $documentItem ? $documentItem.dataset.id : null;
 
-    if ($documentItem) {
-      const $child = $documentItem.children[1];
-      const { id } = $documentItem.dataset;
-
-      if ($child) {
-        if (e.target.className === "toggle") {
-          const isFolded = $child.classList.contains("fold");
-
-          if (isFolded) {
-            $child.classList.remove("fold");
-            $child.classList.add("show");
-          } else {
-            $child.classList.remove("show");
-            $child.classList.add("fold");
-          }
-        } else {
-          onDocumentItemClick(id);
-        }
+    if (e.target.className === "add-document") {
+      let state = { parentId: id };
+      push("/document/new", state);
+    } else if (e.target.className === "toggle") {
+      const $hideItem = $documentItem.closest(".documents-item").children[1];
+      if ($hideItem) {
+        $hideItem.classList.toggle("fold");
+        $hideItem.classList.toggle("show");
       }
+    } else if ($documentItem) {
+      push(`/document/${id}`);
     }
   });
 }

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -1,62 +1,78 @@
-export default function DocumentList({$target, initialState}) {
-    const $document = document.createElement('div');
-    $target.appendChild($document);
-    
-    this.state = initialState;
+export default function DocumentList({
+  $target,
+  initialState,
+  onDocumentItemClick,
+}) {
+  const $document = document.createElement("div");
+  $document.setAttribute("class", "documents-container");
 
-    this.setState = (nextState) => {
-        this.state = nextState;
-        this.render();
+  $target.appendChild($document);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  const documentPrint = (documents) => {
+    let htmlString = "";
+    documents.forEach((document) => {
+      htmlString += `
+        <div class="documents-item" data-id="${document.id}">
+            <div class="document-item-title-wrap">
+                <button class="toggle">></button>
+                <span>${document.title}</span>
+            </div>
+            <div class="documents-item fold">
+                ${
+                  document.documents && document.documents.length !== 0
+                    ? documentPrint(document.documents)
+                    : '<span class="end-document-item">하위 페이지 없음</span>'
+                }
+            </div>
+        </div>
+    `;
+    });
+
+    return htmlString;
+  };
+
+  this.render = () => {
+    if (this.state.length === 0) {
+      $document.innerHTML += "";
+      return;
     }
 
-    const documentPrint = (documents) => {
-        let htmlString = '';
-        documents.forEach(document => {
-            htmlString += `
-                <div class="documents-item" data-id="${document.id}">
-                    <span>${document.title}</span>
-                    <div class="documents-item fold">
-                        ${document.documents && document.documents.length !== 0 ? documentPrint(document.documents) : '<span class="end-document-item">하위 페이지 없음</span>'}
-                    </div>
-                </div>
-            `;
-        });
-
-        return htmlString;
-    }
-
-    this.render = () => {
-        if(this.state.length === 0) {
-            $document.innerHTML = '';
-            return;
-        }
-
-        $document.innerHTML = `
+    $document.innerHTML += `
             ${documentPrint(this.state)}
         `;
-    }
+  };
 
-    this.render();
+  this.render();
 
-    $document.addEventListener('click', (e) => {
-        const $documentItem = e.target.closest('.documents-item');
+  $document.addEventListener("click", (e) => {
+    const $documentItem = e.target.closest(".documents-item");
 
-        if($documentItem) {
-            const $child = $documentItem.children[1];
+    if ($documentItem) {
+      const $child = $documentItem.children[1];
+      const { id } = $documentItem.dataset;
 
-            if($child) {
-                const isFolded = $child.classList.contains('fold');
+      if ($child) {
+        if (e.target.className === "toggle") {
+          const isFolded = $child.classList.contains("fold");
 
-                if(isFolded) {
-                    $child.classList.remove('fold');
-                    $child.classList.add('show');
-                } else {
-                    $child.classList.remove('show');
-                    $child.classList.add('fold');
-                } 
-            }
-                    
+          if (isFolded) {
+            $child.classList.remove("fold");
+            $child.classList.add("show");
+          } else {
+            $child.classList.remove("show");
+            $child.classList.add("fold");
+          }
+        } else {
+          onDocumentItemClick(id);
         }
-    })
+      }
+    }
+  });
 }
-

--- a/src/components/DocumentList.js
+++ b/src/components/DocumentList.js
@@ -20,13 +20,23 @@ export default function DocumentList({
   const documentPrint = (documents) => {
     let htmlString = "";
     documents.forEach((document) => {
+
       htmlString += `
         <div class="documents-item">
-            <div class="document-item-title-wrap" data-id="${document.id}">
-                <button class="toggle">></button>
-                <span>${document.title}</span>
-                <button class="add-document">➕</button>
-                <button class="remove-document">❌</button>
+            <div class="document-item-title-wrap ${document.id === parseInt(this.state.documentId) ? 'selected-document' : ''}" data-id="${document.id}">
+                <button class="toggle">
+                  <i class="fas fa-chevron-right" style="color: #797979;"></i>
+                </button>
+                <span class="document-item-title">${document.title}</span>
+                <div class="action-buttons">
+                  <button class="remove-document">
+                    <i class="fas fa-trash-alt" style="color: #797979;"></i>
+                  </button>
+                  <button class="add-document">
+                    <i class="fas fa-plus" style="color: #797979;"></i>
+                  </button>
+                </div>
+                
             </div>
             <div class="documents-item fold">
                 ${
@@ -44,16 +54,20 @@ export default function DocumentList({
 
   this.render = () => {
     $document.innerHTML = `
-        <button class="add-document">➕</button>
-        <div class="document-items"></div>
+      <div class="add-document-wrap">
+        <button class="add-document">
+          <i class="fas fa-plus-circle" style="color: #797979;"></i>
+        </button>
+        새 페이지
+      </div>
+      <div class="document-items"></div>
     `;
 
     if (this.state.length === 0) {
       return;
     }
-
     $document.querySelector(".document-items").innerHTML = `
-        ${documentPrint(this.state)}
+        ${documentPrint(this.state.documents)}
     `;
   };
 
@@ -62,19 +76,35 @@ export default function DocumentList({
   $document.addEventListener("click", (e) => {
     const $documentItem = e.target.closest(".document-item-title-wrap");
     const id = $documentItem ? $documentItem.dataset.id : null;
+    const $button = e.target.closest("button");
 
-    if (e.target.className === "add-document") {
-      let state = { parentId: id };
-      push("/document/new", state);
-    } else if (e.target.className === "toggle") {
-      const $hideItem = $documentItem.closest(".documents-item").children[1];
-      if ($hideItem) {
-        $hideItem.classList.toggle("fold");
-        $hideItem.classList.toggle("show");
+    if(e.target.className === 'add-document-wrap') {
+      push("/document/new");
+      return;
+    }
+
+    if ($button) {
+      const { className } = $button;
+      if (className === "add-document") {
+        let state = { parentId: id };
+        push("/document/new", state);
+      } else if (className === "toggle") {
+        const $hideItem = $documentItem.closest(".documents-item").children[1];
+        if ($hideItem) {
+          $hideItem.classList.toggle("fold");
+          $hideItem.classList.toggle("show");
+        }
+      } else if (className === "remove-document") {
+        onDocumentRemove(id);
       }
-    } else if (e.target.className === "remove-document") {
-      onDocumentRemove(id);
     } else if ($documentItem) {
+      const $title = $documentItem.querySelector('.document-item-title');
+      if($title) {
+        this.setState({
+          ...this.state,
+          documentId: id
+        })
+      }
       push(`/document/${id}`);
     }
   });

--- a/src/components/EditButtons.js
+++ b/src/components/EditButtons.js
@@ -24,46 +24,35 @@ export default function EditButtons({ $target, initialState, onClick }) {
 
   this.render = () => {};
 
-  $div.addEventListener("click", (e) => {
-    const { className } = e.target.closest('button');
+  const toggleTag = (markDownSyntax, tag) => {
     const selection = window.getSelection();
-    let nextContent;
-    if (className === "bold-button") {
-      const textContent = selection.toString();
-      const styledText = `**${textContent}**`;
-      nextContent = this.state.replace(textContent, styledText);
-      const { outerHTML } = selection.focusNode.parentNode;
-      const isStrong = outerHTML.indexOf("<b>");
+    const textContent = selection.toString();
+    const styledText = `${markDownSyntax}${textContent}${markDownSyntax}`;
+    const { outerHTML } = selection.focusNode.parentNode;
+    const hasTag = outerHTML.includes(tag);
 
-      if (isStrong !== -1) {
-        nextContent = this.state.replace(styledText, textContent);
-      }
+    if (hasTag) {
+      onClick(this.state.replace(styledText, textContent));
+    } else {
+      onClick(this.state.replace(textContent, styledText));
+    }
+  };
 
-      onClick(nextContent);
-    } else if (className === "italic-button") {
-      const textContent = selection.toString();
-      const styledText = `_${textContent}_`;
-      nextContent = this.state.replace(textContent, styledText);
-      const { outerHTML } = selection.focusNode.parentNode;
-      const isItalic = outerHTML.indexOf("<i>");
+  $div.addEventListener("click", (e) => {
+    const { className } = e.target.closest("button");
 
-      if (isItalic !== -1) {
-        nextContent = this.state.replace(styledText, textContent);
-      }
-
-      onClick(nextContent);
-    } else if (className === "strike-button") {
-      const textContent = selection.toString();
-      const styledText = `~~${textContent}~~`;
-      nextContent = this.state.replace(textContent, styledText);
-      const { outerHTML } = selection.focusNode.parentNode;
-      const isStrike = outerHTML.indexOf("<s>");
-
-      if (isStrike !== -1) {
-        nextContent = this.state.replace(styledText, textContent);
-      }
-
-      onClick(nextContent);
+    switch (className) {
+      case "bold-button":
+        toggleTag("**", "<b>");
+        break;
+      case "italic-button":
+        toggleTag("_", "<i>");
+        break;
+      case "strike-button":
+        toggleTag("~~", "<s>");
+        break;
+      default:
+        break;
     }
   });
 }

--- a/src/components/EditButtons.js
+++ b/src/components/EditButtons.js
@@ -1,0 +1,63 @@
+export default function EditButtons({ $target, initialState, onClick }) {
+  const $div = document.createElement("div");
+  $div.setAttribute("class", "edit-button-wrap");
+  $target.appendChild($div);
+
+  $div.innerHTML = `
+    <button class="bold-button">bold</bold>
+    <button class="italic-button">italic</bold>
+    <button class="strike-button">strike</bold>
+  `;
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.render = () => {};
+
+  $div.addEventListener("click", (e) => {
+    const { className } = e.target;
+    const selection = window.getSelection();
+    let nextContent;
+    if (className === "bold-button") {
+      const textContent = selection.toString();
+      const styledText = `**${textContent}**`;
+      nextContent = this.state.replace(textContent, styledText);
+      const { outerHTML } = selection.focusNode.parentNode;
+      const isStrong = outerHTML.indexOf("<b>");
+
+      if (isStrong !== -1) {
+        nextContent = this.state.replace(styledText, textContent);
+      }
+
+      onClick(nextContent);
+    } else if (className === "italic-button") {
+      const textContent = selection.toString();
+      const styledText = `_${textContent}_`;
+      nextContent = this.state.replace(textContent, styledText);
+      const { outerHTML } = selection.focusNode.parentNode;
+      const isItalic = outerHTML.indexOf("<i>");
+
+      if (isItalic !== -1) {
+        nextContent = this.state.replace(styledText, textContent);
+      }
+
+      onClick(nextContent);
+    } else if (className === "strike-button") {
+      const textContent = selection.toString();
+      const styledText = `~~${textContent}~~`;
+      nextContent = this.state.replace(textContent, styledText);
+      const { outerHTML } = selection.focusNode.parentNode;
+      const isStrike = outerHTML.indexOf("<s>");
+
+      if (isStrike !== -1) {
+        nextContent = this.state.replace(styledText, textContent);
+      }
+
+      onClick(nextContent);
+    }
+  });
+}

--- a/src/components/EditButtons.js
+++ b/src/components/EditButtons.js
@@ -1,6 +1,6 @@
 export default function EditButtons({ $target, initialState, onClick }) {
   const $div = document.createElement("div");
-  $div.setAttribute("class", "edit-button-wrap");
+  $div.setAttribute("class", "hide edit-button-wrap");
   $target.appendChild($div);
 
   $div.innerHTML = `

--- a/src/components/EditButtons.js
+++ b/src/components/EditButtons.js
@@ -4,9 +4,15 @@ export default function EditButtons({ $target, initialState, onClick }) {
   $target.appendChild($div);
 
   $div.innerHTML = `
-    <button class="bold-button">bold</bold>
-    <button class="italic-button">italic</bold>
-    <button class="strike-button">strike</bold>
+    <button class="bold-button">
+        <i class="fas fa-bold"></i>
+    </bold>
+    <button class="italic-button">
+        <i class="fas fa-italic"></i>
+    </bold>
+    <button class="strike-button">
+        <i class="fas fa-strikethrough"></i>
+    </bold>
   `;
 
   this.state = initialState;
@@ -19,7 +25,7 @@ export default function EditButtons({ $target, initialState, onClick }) {
   this.render = () => {};
 
   $div.addEventListener("click", (e) => {
-    const { className } = e.target;
+    const { className } = e.target.closest('button');
     const selection = window.getSelection();
     let nextContent;
     if (className === "bold-button") {

--- a/src/components/EditButtons.js
+++ b/src/components/EditButtons.js
@@ -5,14 +5,14 @@ export default function EditButtons({ $target, initialState, onClick }) {
 
   $div.innerHTML = `
     <button class="bold-button">
-        <i class="fas fa-bold"></i>
-    </bold>
+      <i class="fas fa-bold"></i>
+    </button>
     <button class="italic-button">
-        <i class="fas fa-italic"></i>
-    </bold>
+      <i class="fas fa-italic"></i>
+    </button>
     <button class="strike-button">
-        <i class="fas fa-strikethrough"></i>
-    </bold>
+      <i class="fas fa-strikethrough"></i>
+    </button>
   `;
 
   this.state = initialState;

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -3,7 +3,7 @@ import { transformTag, transformText, deleteText } from "../utils/transform.js";
 
 export default function Editor({ $target, initialState, onEditing }) {
   const $editor = document.createElement("div");
-  $editor.setAttribute("class", "editor-wrap");
+  $editor.className = "editor-wrap";
 
   $editor.innerHTML = `
     <input type="text" id="editor-title" name="title" placeholder="제목을 입력해주세요." />
@@ -76,7 +76,7 @@ export default function Editor({ $target, initialState, onEditing }) {
     const elementPosition = getPosition(node.parentElement, offset);
 
     const $empty = document.createElement("span");
-    $empty.setAttribute("class", "empty");
+    $empty.className = "empty";
 
     // 변환이 되면서 줄어든 문자열을 반영
     const text = transformText(node.data);

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,35 +1,178 @@
+import EditButtons from "./EditButtons.js";
+
 export default function Editor({ $target, initialState, onEditing }) {
   const $editor = document.createElement("div");
   $editor.setAttribute("class", "editor-wrap");
 
   $editor.innerHTML = `
     <input type="text" id="editor-title" name="title" placeholder="제목을 입력해주세요." />
-    <textarea id="editor-content" name="content"></textarea>
+    <div id="editor-content" contentEditable="true" style="width: 600px;"></div>
   `;
+
   $target.appendChild($editor);
+
+  const $content = $editor.querySelector("#editor-content");
+
+  const editButtons = new EditButtons({
+    $target: $editor,
+    onClick: (nextContent) => {
+      this.setState({
+        ...this.state,
+        content: nextContent,
+      });
+      onEditing(this.state);
+      $content.blur();
+    },
+  });
 
   this.state = initialState;
 
   this.setState = (nextState) => {
     this.state = nextState;
     $editor.querySelector("#editor-title").value = this.state.title || "";
-    $editor.querySelector("#editor-content").value = this.state.content || "";
+    $editor.querySelector("#editor-content").innerHTML =
+      this.state.content || "";
+    editButtons.setState(this.state.content);
+    this.render();
   };
 
-  this.render = () => {};
+  this.render = () => {
+    let richContent = this.state.content
+      .split("<div>")
+      .map((line) => {
+        if (line.indexOf("# ") === 0) {
+          return `<h1>${line.substr(2)}</h1>`;
+        } else if (line.indexOf("## ") === 0) {
+          return `<h2>${line.substr(3)}</h2>`;
+        } else if (line.indexOf("### ") === 0) {
+          return `<h3>${line.substr(4)}</h3>`;
+        } else if (line.indexOf("#### ") === 0) {
+          return `<h4>${line.substr(5)}</h4>`;
+        } else if (line.indexOf("**") !== -1) {
+          const startIndex = line.indexOf("**");
+          const endIndex = line.lastIndexOf("**");
+          if (endIndex > 0) {
+            const before = line.slice(0, startIndex);
+            const after = line.slice(endIndex + 2);
+            const slicedText = line.slice(startIndex + 2, endIndex);
+            return `${before}<b>${slicedText}</b>${after}`;
+          } else {
+            return line;
+          }
+        } else if (line.indexOf("_") !== -1) {
+          const startIndex = line.indexOf("_");
+          const endIndex = line.lastIndexOf("_");
+          if (endIndex > 0) {
+            const before = line.slice(0, startIndex);
+            const after = line.slice(endIndex + 1);
+            const slicedText = line.slice(startIndex + 1, endIndex);
+            return `${before}<i>${slicedText}</i>${after}`;
+          } else {
+            return line;
+          }
+        } else if (line.indexOf("~~") !== -1) {
+          const startIndex = line.indexOf("~~");
+          const endIndex = line.lastIndexOf("~~");
+          if (endIndex > 0) {
+            const before = line.slice(0, startIndex);
+            const after = line.slice(endIndex + 2);
+            const slicedText = line.slice(startIndex + 2, endIndex);
+            return `${before}<s>${slicedText}</s>${after}`;
+          } else {
+            return line;
+          }
+        }
+        return line;
+      })
+      .filter((e) => e != "")
+      .join("<div>");
 
-  $editor.addEventListener("keyup", (e) => {
-    const { name } = e.target;
+    richContent = richContent
+      .replace(/&nbsp;/g, " ")
+      .replace(/\n/g, "<br>")
+      .replace(/<i><\/i>/g, "")
+      .replace(/<b><\/b>/g, "")
+      .replace(/<s><\/s>/g, "")
+      .replace(/<div><br><\/div>/gi, "<br>");
+
+    $editor.querySelector("#editor-title").value = this.state.title;
+    $editor.querySelector("#editor-content").innerHTML = richContent;
+  };
+
+  $editor.querySelector("#editor-title").addEventListener("keyup", (e) => {
     const parentId = history.state ? history.state.parentId : null;
 
-    if (this.state[name] !== undefined) {
-      this.setState({
-        ...this.state,
-        [name]: e.target.value,
-        parentId,
-      });
+    this.setState({
+      ...this.state,
+      title: e.target.value,
+      parentId,
+    });
 
-      onEditing(this.state);
-    }
+    onEditing(this.state);
   });
+
+  $content.addEventListener("compositionend", (e) => {
+    const selection = window.getSelection();
+    const node = selection.focusNode;
+    const offset = selection.focusOffset;
+    const postion = getCursorPosition($content, node, offset, {
+      postion: 0,
+      done: false,
+    });
+
+    if (offset === 0) postion.postion += 0.5;
+
+    this.setState({
+      ...this.state,
+      content: e.target.innerHTML,
+    });
+
+    selection.removeAllRanges();
+    const range = setCursorPosition($content, document.createRange(), {
+      postion: postion.postion,
+      done: false,
+    });
+
+    range.collapse(true);
+    selection.addRange(range);
+    onEditing(this.state);
+  });
+
+  const getCursorPosition = (parent, node, offset, state) => {
+    if (state.done) return state;
+
+    let currentNode = null;
+    if (parent.childNodes.length == 0) {
+      state.postion += parent.textContent.length;
+    } else {
+      for (let i = 0; i < parent.childNodes.length && !state.done; i++) {
+        currentNode = parent.childNodes[i];
+        if (currentNode === node) {
+          state.postion += offset;
+          state.done = true;
+          return state;
+        } else getCursorPosition(currentNode, node, offset, state);
+      }
+    }
+    return state;
+  };
+
+  const setCursorPosition = (parent, range, state) => {
+    if (state.done) return range;
+
+    if (parent.childNodes.length == 0) {
+      if (parent.textContent.length >= state.postion) {
+        range.setStart(parent, state.postion);
+        state.done = true;
+      } else {
+        state.postion = state.postion - parent.textContent.length;
+      }
+    } else {
+      for (let i = 0; i < parent.childNodes.length && !state.done; i++) {
+        let currentNode = parent.childNodes[i];
+        setCursorPosition(currentNode, range, state);
+      }
+    }
+    return range;
+  };
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -31,11 +31,13 @@ export default function Editor({ $target, initialState, onEditing }) {
 
   $editor.addEventListener("keyup", (e) => {
     const { name } = e.target;
+    const parentId = history.state ? history.state.parentId : null;
 
     if (this.state[name] !== undefined) {
       this.setState({
         ...this.state,
         [name]: e.target.value,
+        parentId,
       });
 
       onEditing(this.state);

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,0 +1,30 @@
+export default function Editor({ $target, initialState, onEditing }) {
+  const $editor = document.createElement("div");
+  $editor.setAttribute("class", "editor-container");
+  $editor.innerHTML = `
+    <input type="text" id="editor-title" name="title" />
+    <textarea id="editor-content" name="content"></textarea>
+  `;
+  $target.appendChild($editor);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    $editor.querySelector("#editor-title").value = this.state.title || "";
+    $editor.querySelector("#editor-content").value = this.state.content || "";
+  };
+
+  this.render = () => {};
+
+  $editor.addEventListener("keyup", (e) => {
+    const { name } = e.target;
+
+    this.setState({
+      ...this.state,
+      [name]: e.target.value,
+    });
+
+    onEditing(this.state);
+  });
+}

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -3,12 +3,10 @@ export default function Editor({ $target, initialState, onEditing }) {
   $editor.setAttribute("class", "editor-wrap");
 
   $editor.innerHTML = `
-    <input type="text" id="editor-title" name="title" />
+    <input type="text" id="editor-title" name="title" placeholder="제목을 입력해주세요." />
     <textarea id="editor-content" name="content"></textarea>
   `;
   $target.appendChild($editor);
-
-  let init = false;
 
   this.state = initialState;
 
@@ -16,18 +14,9 @@ export default function Editor({ $target, initialState, onEditing }) {
     this.state = nextState;
     $editor.querySelector("#editor-title").value = this.state.title || "";
     $editor.querySelector("#editor-content").value = this.state.content || "";
-    this.render();
   };
 
-  this.render = () => {
-    if (!init) {
-      $editor.innerHTML = `
-        <input type="text" id="editor-title" name="title" class="test"/>
-        <textarea id="editor-content" name="content"></textarea>
-      `;
-      init = true;
-    }
-  };
+  this.render = () => {};
 
   $editor.addEventListener("keyup", (e) => {
     const { name } = e.target;

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -48,7 +48,8 @@ export default function Editor({ $target, initialState, onEditing }) {
           return `<h3>${line.substr(4)}</h3>`;
         } else if (line.indexOf("#### ") === 0) {
           return `<h4>${line.substr(5)}</h4>`;
-        } else if (line.indexOf("**") !== -1) {
+        }
+        if (line.indexOf("**") !== -1) {
           const startIndex = line.indexOf("**");
           const endIndex = line.lastIndexOf("**");
           if (endIndex > 0) {
@@ -59,7 +60,8 @@ export default function Editor({ $target, initialState, onEditing }) {
           } else {
             return line;
           }
-        } else if (line.indexOf("_") !== -1) {
+        }
+        if (line.indexOf("_") !== -1) {
           const startIndex = line.indexOf("_");
           const endIndex = line.lastIndexOf("_");
           if (endIndex > 0) {
@@ -70,7 +72,8 @@ export default function Editor({ $target, initialState, onEditing }) {
           } else {
             return line;
           }
-        } else if (line.indexOf("~~") !== -1) {
+        }
+        if (line.indexOf("~~") !== -1) {
           const startIndex = line.indexOf("~~");
           const endIndex = line.lastIndexOf("~~");
           if (endIndex > 0) {
@@ -175,4 +178,22 @@ export default function Editor({ $target, initialState, onEditing }) {
     }
     return range;
   };
+
+  document.addEventListener("selectionchange", () => {
+    const $editBox = $editor.querySelector(".edit-button-wrap");
+
+    if (!document.getSelection().isCollapsed) {
+      const { parentElement } = document.getSelection().focusNode;
+      const rect = parentElement.getBoundingClientRect();
+
+      const x = rect.left - 370;
+      const y = rect.top - 90;
+
+      $editBox.style.top = `${y}px`;
+      $editBox.style.left = `${x}px`;
+      $editBox.classList.remove("hide");
+    } else {
+      $editBox.classList.add("hide");
+    }
+  });
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,11 +1,14 @@
 export default function Editor({ $target, initialState, onEditing }) {
   const $editor = document.createElement("div");
-  $editor.setAttribute("class", "editor-container");
+  $editor.setAttribute("class", "editor-wrap");
+
   $editor.innerHTML = `
     <input type="text" id="editor-title" name="title" />
     <textarea id="editor-content" name="content"></textarea>
   `;
   $target.appendChild($editor);
+
+  let init = false;
 
   this.state = initialState;
 
@@ -13,18 +16,29 @@ export default function Editor({ $target, initialState, onEditing }) {
     this.state = nextState;
     $editor.querySelector("#editor-title").value = this.state.title || "";
     $editor.querySelector("#editor-content").value = this.state.content || "";
+    this.render();
   };
 
-  this.render = () => {};
+  this.render = () => {
+    if (!init) {
+      $editor.innerHTML = `
+        <input type="text" id="editor-title" name="title" class="test"/>
+        <textarea id="editor-content" name="content"></textarea>
+      `;
+      init = true;
+    }
+  };
 
   $editor.addEventListener("keyup", (e) => {
     const { name } = e.target;
 
-    this.setState({
-      ...this.state,
-      [name]: e.target.value,
-    });
+    if (this.state[name] !== undefined) {
+      this.setState({
+        ...this.state,
+        [name]: e.target.value,
+      });
 
-    onEditing(this.state);
+      onEditing(this.state);
+    }
   });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,33 @@
+import DocumentList from "./components/DocumentList.js";
+
+const testData = [
+    {
+      "id": 1,
+      "title": "노션을 만들자",
+      "documents": [
+        {
+          "id": 2,
+          "title": "블라블라",
+          "documents": [
+            {
+              "id": 3,
+              "title": "함냐함냐",
+              "documents": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "hello!",
+      "documents": []
+    }
+];
+
+const $app = document.querySelector('#app');
+
+const documentList = new DocumentList({
+    $target: $app,
+    initialState: testData
+})

--- a/src/main.js
+++ b/src/main.js
@@ -4,4 +4,11 @@ const $app = document.querySelector("#app");
 
 new App({
   $target: $app,
+  initialState: {
+    documentId: 0,
+    document: {
+      title: "",
+      content: "",
+    },
+  },
 });

--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,12 @@ const $app = document.querySelector("#app");
 
 new App({
   $target: $app,
-  // initialState: {
-  //   documentId: 0,
-  //   document: {
-  //     title: "",
-  //     content: "",
-  //   },
-  // },
+  initialState: {
+    documentId: 0,
+    documents: [],
+    selectedDocument: {
+      title: "",
+      content: "",
+    },
+  },
 });

--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,11 @@ const $app = document.querySelector("#app");
 
 new App({
   $target: $app,
-  initialState: {
-    documentId: 0,
-    document: {
-      title: "",
-      content: "",
-    },
-  },
+  // initialState: {
+  //   documentId: 0,
+  //   document: {
+  //     title: "",
+  //     content: "",
+  //   },
+  // },
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,33 +1,7 @@
-import DocumentList from "./components/DocumentList.js";
+import App from "./components/App.js";
 
-const testData = [
-    {
-      "id": 1,
-      "title": "노션을 만들자",
-      "documents": [
-        {
-          "id": 2,
-          "title": "블라블라",
-          "documents": [
-            {
-              "id": 3,
-              "title": "함냐함냐",
-              "documents": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "hello!",
-      "documents": []
-    }
-];
+const $app = document.querySelector("#app");
 
-const $app = document.querySelector('#app');
-
-const documentList = new DocumentList({
-    $target: $app,
-    initialState: testData
-})
+new App({
+  $target: $app,
+});

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,17 @@
+.fold {
+    display: none;
+}
+
+.show {
+    display: block;
+}
+
+.documents-item {
+    cursor: pointer;
+    padding-left: 10px;
+}
+
+.end-document-item {
+    cursor: default;
+    color: gray;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -111,15 +111,20 @@ html, body {
 .editor-wrap {
     display: flex;
     flex-direction: column;
+    position: relative;
     margin-top: 80px;
 }
 
 .edit-button-wrap {
     display: flex;
     align-items: center;
-    border: 1px solid gray;
-    border-radius: 5px;
+    position: absolute;
     padding: 5px;
+    border: none;
+    border-radius: 5px;
+    background: white;
+    transform: translateY(-110%);
+    box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, rgba(15, 15, 15, 0.1) 0px 3px 6px, rgba(15, 15, 15, 0.2) 0px 9px 24px;
     box-sizing: border-box;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -35,7 +35,7 @@ html, body {
     color: gray;
 }
 
-.editor-section {
+.editor-page {
     width: 100%;
 }
 
@@ -44,7 +44,7 @@ html, body {
     height: 300px;
 }
 
-.editor-container {
+.editor-wrap {
     display: flex;
     flex-direction: column;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,9 +1,28 @@
+html, body {
+    margin: 0;
+    height: 100%;
+}
+
+#app {
+    display: flex;
+    height: 100%;
+}
+
 .fold {
     display: none;
 }
 
 .show {
     display: block;
+}
+
+.documents-container {
+    width: 300px;
+    height: 100%;
+    padding: 10px;
+    border-right: 1px solid gray;
+    background: #fbfbfa;
+    box-sizing: border-box;
 }
 
 .documents-item {
@@ -14,4 +33,18 @@
 .end-document-item {
     cursor: default;
     color: gray;
+}
+
+.editor-section {
+    width: 100%;
+}
+
+#editor-content {
+    resize: none;
+    height: 300px;
+}
+
+.editor-container {
+    display: flex;
+    flex-direction: column;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -16,35 +16,122 @@ html, body {
     display: block;
 }
 
+.action-buttons {
+    display: none;
+}
+
 .documents-container {
     width: 300px;
     height: 100%;
     padding: 10px;
-    border-right: 1px solid gray;
+    border-right: 1px solid #d0d0d0;
     background: #fbfbfa;
     box-sizing: border-box;
+}
+
+.add-document-wrap {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 0px;
+    padding-left: 10px;
+    padding-left: 10px;
+    cursor: pointer;
+}
+
+.add-document-wrap:hover {
+    display: flex;
+    align-items: center;
+    background: #e4e4e4;
+    border-radius: 4px;
 }
 
 .documents-item {
     cursor: pointer;
     padding-left: 10px;
+
+}
+
+.document-item-title-wrap {
+    display: flex;
+    padding: 5px 0px;
+    display: flex;
+    gap: 5px;
+}
+
+.document-item-title-wrap:hover > .action-buttons  {
+    display: flex;
+}
+
+.document-item-title-wrap:hover  {
+    background: #e4e4e4;
+    border-radius: 4px;
+}
+
+.document-item-title {
+    flex: 1 0 auto;
+    color: #74736e;
+}
+
+.selected-document {
+    background: #f1f1f0;
+    border-radius: 4px;
+}
+
+.selected-document span {
+    font-weight: bold;
+    color: #37352f;
 }
 
 .end-document-item {
     cursor: default;
-    color: gray;
+    color: #999895;
+    padding-left: 10px;
 }
 
 .editor-page {
-    width: 100%;
+    width: calc(100% - 300px);
+    padding: 10px 70px;
+    box-sizing: border-box;
+}
+
+#editor-title {
+    outline: none;
+    border: none;
+    font-size: 40px;
+    font-weight: bold;
 }
 
 #editor-content {
     resize: none;
-    height: 300px;
+    margin-top: 30px;
+    outline: none;
 }
 
 .editor-wrap {
     display: flex;
     flex-direction: column;
+    margin-top: 80px;
+}
+
+.edit-button-wrap {
+    display: flex;
+    align-items: center;
+    border: 1px solid gray;
+    border-radius: 5px;
+    padding: 5px;
+    box-sizing: border-box;
+}
+
+.hide {
+    display: none;
+}
+
+button {
+    width: 20px;
+    height: 20px;
+    padding: 0px;
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,21 @@
+export const API_END_POINT = "https://kdt-frontend.programmers.co.kr";
+
+export const request = async (url, options = {}) => {
+  try {
+    const res = await fetch(`${API_END_POINT}${url}`, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        "x-username": "KimYugyeong",
+      },
+    });
+
+    if (res.ok) {
+      return await res.json();
+    }
+
+    throw new Error("API 처리중 오류가 발생했습니다.");
+  } catch (e) {
+    alert(e.message);
+  }
+};

--- a/src/utils/route.js
+++ b/src/utils/route.js
@@ -1,0 +1,22 @@
+const ROUTE_CHANGE_EVENT_NAME = "route-change";
+
+export const initRouter = (onRoute) => {
+  window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
+    const { nextUrl } = e.detail;
+
+    if (nextUrl) {
+      history.pushState(null, null, nextUrl);
+      onRoute();
+    }
+  });
+};
+
+export const push = (nextUrl) => {
+  window.dispatchEvent(
+    new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
+      detail: {
+        nextUrl,
+      },
+    })
+  );
+};

--- a/src/utils/route.js
+++ b/src/utils/route.js
@@ -3,9 +3,10 @@ const ROUTE_CHANGE_EVENT_NAME = "route-change";
 export const initRouter = (onRoute) => {
   window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
     const { nextUrl } = e.detail;
+    const { pathname } = window.location;
     const state = e.detail.state ? e.detail.state : null;
 
-    if (nextUrl) {
+    if (nextUrl && nextUrl !== pathname) {
       history.pushState(state, null, nextUrl);
       onRoute();
     }

--- a/src/utils/route.js
+++ b/src/utils/route.js
@@ -3,19 +3,21 @@ const ROUTE_CHANGE_EVENT_NAME = "route-change";
 export const initRouter = (onRoute) => {
   window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
     const { nextUrl } = e.detail;
+    const state = e.detail.state ? e.detail.state : null;
 
     if (nextUrl) {
-      history.pushState(null, null, nextUrl);
+      history.pushState(state, null, nextUrl);
       onRoute();
     }
   });
 };
 
-export const push = (nextUrl) => {
+export const push = (nextUrl, state) => {
   window.dispatchEvent(
     new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
       detail: {
         nextUrl,
+        state
       },
     })
   );

--- a/src/utils/route.js
+++ b/src/utils/route.js
@@ -2,12 +2,16 @@ const ROUTE_CHANGE_EVENT_NAME = "route-change";
 
 export const initRouter = (onRoute) => {
   window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
-    const { nextUrl } = e.detail;
+    const { nextUrl, type } = e.detail;
     const { pathname } = window.location;
     const state = e.detail.state ? e.detail.state : null;
 
     if (nextUrl && nextUrl !== pathname) {
-      history.pushState(state, null, nextUrl);
+      if(type === 'push') {
+        history.pushState(state, null, nextUrl);
+      } else {
+        history.replaceState(state, null, nextUrl);
+      }
       onRoute();
     }
   });
@@ -18,7 +22,20 @@ export const push = (nextUrl, state) => {
     new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
       detail: {
         nextUrl,
-        state
+        state,
+        type: 'push'
+      },
+    })
+  );
+};
+
+export const replace = (nextUrl, state) => {
+  window.dispatchEvent(
+    new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
+      detail: {
+        nextUrl,
+        state,
+        type: 'replace'
       },
     })
   );

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,22 @@
+const storage = window.localStorage;
+
+export const setItem = (key, value) => {
+    try {
+        storage.setItem(key, JSON.stringify(value))
+    } catch(e) {
+        console.log(e);
+    }
+}
+
+export const getItem = (key, defaultValue) => {
+    try {
+        const storedValue = storage.getItem(key);
+        return storedValue ? JSON.parse(storedValue) : defaultValue;
+    } catch(e) {
+        return defaultValue;
+    }
+}
+
+export const removeItem = (key) => {
+    storage.removeItem(key);
+}

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -1,11 +1,11 @@
 export const transformTag = (text) => {
-  let h1Pattern = /<div>#\s+(.*?)<\/div>/g;
-  let h2Pattern = /<div>##\s+(.*?)<\/div>/g;
-  let h3Pattern = /<div>###\s+(.*?)<\/div>/g;
-  let h4Pattern = /<div>####\s+(.*?)<\/div>/g;
-  let boldPattern = />(.*?)\*\*(.*?)\*\*(.*?)</g;
-  let italicPattern = />(.*?)_(.*?)_(.*?)</g;
-  let strikePattern = />(.*?)~~(.*?)~~(.*?)</g;
+  const h1Pattern = /<div>#\s+(.*?)<\/div>/g;
+  const h2Pattern = /<div>##\s+(.*?)<\/div>/g;
+  const h3Pattern = /<div>###\s+(.*?)<\/div>/g;
+  const h4Pattern = /<div>####\s+(.*?)<\/div>/g;
+  const boldPattern = />(.*?)\*\*(.*?)\*\*(.*?)</g;
+  const italicPattern = />(.*?)_(.*?)_(.*?)</g;
+  const strikePattern = />(.*?)~~(.*?)~~(.*?)</g;
 
   return text
     .replace(h1Pattern, "<div><h1>$1</h1></div>")

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -1,0 +1,57 @@
+export const transformTag = (text) => {
+  let h1Pattern = /<div>#\s+(.*?)<\/div>/g;
+  let h2Pattern = /<div>##\s+(.*?)<\/div>/g;
+  let h3Pattern = /<div>###\s+(.*?)<\/div>/g;
+  let h4Pattern = /<div>####\s+(.*?)<\/div>/g;
+  let boldPattern = />(.*?)\*\*(.*?)\*\*(.*?)</g;
+  let italicPattern = />(.*?)_(.*?)_(.*?)</g;
+  let strikePattern = />(.*?)~~(.*?)~~(.*?)</g;
+
+  return text
+    .replace(h1Pattern, "<div><h1>$1</h1></div>")
+    .replace(h2Pattern, "<div><h2>$1</h2></div>")
+    .replace(h3Pattern, "<div><h3>$1</h3></div>")
+    .replace(h4Pattern, "<div><h4>$1</h4></div>")
+    .replace(boldPattern, ">$1<b>$2</b>$3<")
+    .replace(italicPattern, ">$1<i>$2</i>$3<")
+    .replace(strikePattern, ">$1<s>$2</s>$3<")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\n/g, "<br>")
+    .replace(/<h1><br><\/h1>/g, "<br>")
+    .replace(/<h2><br><\/h2>/g, "<br>")
+    .replace(/<h3><br><\/h3>/g, "<br>")
+    .replace(/<h4><br><\/h4>/g, "<br>")
+    .replace(/<i><br><\/i>/g, "<br>")
+    .replace(/<b><br><\/b>/g, "<br>")
+    .replace(/<s><br><\/s>/g, "<br>");
+};
+
+export const transformText = (text) => {
+  if (text.indexOf("#") === 0) {
+    text = text
+      .replace("#### ", "")
+      .replace("### ", "")
+      .replace("## ", "")
+      .replace("# ", "");
+  }
+
+  return text
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/_(.*?)_/g, "$1")
+    .replace(/~~(.*?)~~/g, "$1");
+};
+
+export const deleteText = (text) => {
+  if (text.indexOf("#") === 0) {
+    text = text
+      .replace("#### ", "")
+      .replace("### ", "")
+      .replace("## ", "")
+      .replace("# ", "");
+  }
+
+  return text
+    .replace(/(.*?)\*\*(.*?)\*\*/g, "")
+    .replace(/(.*?)_(.*?)_/g, "")
+    .replace(/(.*?)~~(.*?)~~/g, "");
+};


### PR DESCRIPTION
## 📌 과제 설명
바닐라JS를 이용해 노션 클로닝 프로젝트를 수행하였습니다.

## 👩‍💻 요구 사항과 구현 내용
![image](https://github.com/prgrms-fe-devcourse/FEDC5-5_Project_Notion_VanillaJS/assets/66080362/56d1bfb6-7522-47d5-bc10-8a2b2901593c)

### 기본 요구 사항
- [x] 바닐라 JS만을 이용해 노션을 클로닝합니다.
- [x] 기본적인 레이아웃은 노션과 같으며, 스타일링, 컬러값 등은 원하는대로 커스텀합니다.
- [x] 글 단위를 Document라고 합니다. Document는 Document 여러개를 포함할 수 있습니다.
- [x] 화면 좌측에 Root Documents를 불러오는 API를 통해 루트 Documents를 렌더링합니다.
- [x] Root Document를 클릭하면 오른쪽 편집기 영역에 해당 Document의 Content를 렌더링합니다.
- [x] 해당 Root Document에 하위 Document가 있는 경우, 해당 Document 아래에 트리 형태로 렌더링 합니다.
- [x] Document Tree에서 각 Document 우측에는 + 버튼이 있습니다. 해당 버튼을 클릭하면, 클릭한 Document의 하위 Document로 새 Document를 생성하고 편집화면으로 넘깁니다.
- [x] 편집기에는 기본적으로 저장 버튼이 없습니다. Document Save API를 이용해 지속적으로 서버에 저장되도록 합니다.
- [x] History API를 이용해 SPA 형태로 만듭니다.
- [x] 루트 URL 접속 시엔 별다른 편집기 선택이 안 된 상태입니다.
- [x] /documents/{documentId} 로 접속시, 해당 Document 의 content를 불러와 편집기에 로딩합니다.

### 보너스 요구사항
- [x] 기본적으로 편집기는 textarea 기반으로 단순한 텍스트 편집기로 시작하되, 여력이 되면 div와 contentEditable을 조합해서 좀 더 Rich한 에디터를 만들어봅니다.
- [ ] 편집기 최하단에는 현재 편집 중인 Document의 하위 Document 링크를 렌더링하도록 추가합니다.
- [ ] 편집기 내에서 다른 Document name을 적은 경우, 자동으로 해당 Document의 편집 페이지로 이동하는 링크를 거는 기능을 추가합니다.

### 구현 중 문제점 
- [x] 커서 위치가 이상한 곳으로 가는 문제
- [ ] 삭선, 볼드, 이탤릭을 여러개 적용시키지 못하는 문제
- [ ] 입력중에 api요청이 되면 마지막 글자가 반영 안되는 문제

## ✅ 피드백 반영사항
- [x] 3개이상의 if-else문 switch문으로 변경
- [x] 선언부와 가깝게 변수 위치 변경
- [x] 불필요한 코드 제거 및 오타 수정
- [x] history.replaceState기능의 함수화
- [ ] DocumentListItem 컴포넌트화

## ✅ PR 포인트 & 궁금한 점
- 기능이 많아지면서 커밋메시지가 제대로 쪼개지지 못한 거 같은데 커밋 메시지를 더 잘게 쪼개야할지 아니면 묶어서 해도되는지 궁금합니다.
- 컴포넌트가 서로 의존성이 낮도록 잘 분리되었는지 궁금합니다.
- contentEditable활용하면서 커서 문제를 아직 해결하지 못했는데 setState를 없애서 하는 것이 나을까요, 아니면 setState로 변경될때마다 커서를 찾아주는 것이 맞을까요?
- contentEditable에서 innerHTML이 변경될 때마다 정확한 위치에 커서를 둘 수 있는 방법이 궁금합니다.