### PR TITLE
[Project1/정혜연] Notion 클로닝 프로젝트

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -1,1 +1,0 @@
-README2.md

--- a/README2.md
+++ b/README2.md
@@ -1,0 +1,1 @@
+README2.md

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
     <title>Notion Cloning - HY</title>
   </head>
   <body>
+    <link rel="stylesheet" href="style.css" />
     <main id="app"></main>
     <script src="/src/main.js" type="module"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Notion Cloning - HY</title>
+  </head>
+  <body>
+    <main id="app"></main>
+    <script src="./src/main.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@
   </head>
   <body>
     <main id="app"></main>
-    <script src="./src/main.js" type="module"></script>
+    <script src="/src/main.js" type="module"></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -4,13 +4,7 @@ import PostEditPage from "./PostEditPage.js";
 // /posts/{id} -> id에 해당하는 post 생성
 // /posts/new -> 새 post 생성
 export default function App({ $target }) {
-  const postsPage = new PostsPage({
-    $target,
-    onPostClick: (id) => {
-      history.pushState(null, null, `/posts/${id}`);
-      this.route();
-    },
-  });
+  const postsPage = new PostsPage({ $target });
   const postEditPage = new PostEditPage({
     $target,
     initialState: { postId: "new", post: { title: "", content: "" } },
@@ -28,4 +22,15 @@ export default function App({ $target }) {
   };
 
   this.route();
+
+  // nextUrl이 유효할 때만 라우팅 처리
+  // route가 매번 호출 되는 것을 방지
+  window.addEventListener("route-change", (e) => {
+    const { nextUrl } = e.detail;
+
+    if (nextUrl) {
+      history.pushState(null, null, nextUrl);
+      this.route();
+    }
+  });
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ export default function App({ $target }) {
   const postsPage = new PostsPage({ $target });
   const postEditPage = new PostEditPage({
     $target,
-    initialState: { postId: "new" },
+    initialState: { postId: "new", post: { title: "", content: "" } },
   });
 
   this.route = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,25 @@
 import PostsPage from "./PostsPage.js";
+import PostEditPage from "./PostEditPage.js";
 
+// /posts/{id} -> id에 해당하는 post 생성
+// /posts/new -> 새 post 생성
 export default function App({ $target }) {
   const postsPage = new PostsPage({ $target });
+  const postEditPage = new PostEditPage({
+    $target,
+    initialState: { postId: "new" },
+  });
 
-  postsPage.render();
+  this.route = () => {
+    const { pathname } = window.location;
+
+    if (pathname === "/") {
+      postsPage.render();
+    } else if (pathname.indexOf("/posts/") === 0) {
+      const [, , postId] = pathname.split("/");
+      postEditPage.setState({ postId });
+    }
+  };
+
+  this.route();
 }

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ export default function App({ $target }) {
 
     if (pathname === "/") {
       postsPage.render();
-    } else if (pathname.indexOf("/document/") === 0) {
+    } else if (pathname.indexOf("/documents/") === 0) {
       const [, , postId] = pathname.split("/");
       postEditPage.setState({ postId });
     }

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,13 @@ import PostEditPage from "./PostEditPage.js";
 // /posts/{id} -> id에 해당하는 post 생성
 // /posts/new -> 새 post 생성
 export default function App({ $target }) {
-  const postsPage = new PostsPage({ $target });
+  const postsPage = new PostsPage({
+    $target,
+    onPostClick: (id) => {
+      history.pushState(null, null, `/posts/${id}`);
+      this.route();
+    },
+  });
   const postEditPage = new PostEditPage({
     $target,
     initialState: { postId: "new", post: { title: "", content: "" } },

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,7 @@
+import PostsPage from "./PostsPage.js";
+
+export default function App({ $target }) {
+  const postsPage = new PostsPage({ $target });
+
+  postsPage.render();
+}

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ export default function App({ $target }) {
 
     if (pathname === "/") {
       postsPage.render();
-    } else if (pathname.indexOf("/posts/") === 0) {
+    } else if (pathname.indexOf("/document/") === 0) {
       const [, , postId] = pathname.split("/");
       postEditPage.setState({ postId });
     }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import PostsPage from "./PostsPage.js";
 import PostEditPage from "./PostEditPage.js";
+import { initRouter } from "./router.js";
 
 // /posts/{id} -> id에 해당하는 post 생성
 // /posts/new -> 새 post 생성
@@ -23,14 +24,5 @@ export default function App({ $target }) {
 
   this.route();
 
-  // nextUrl이 유효할 때만 라우팅 처리
-  // route가 매번 호출 되는 것을 방지
-  window.addEventListener("route-change", (e) => {
-    const { nextUrl } = e.detail;
-
-    if (nextUrl) {
-      history.pushState(null, null, nextUrl);
-      this.route();
-    }
-  });
+  initRouter(() => this.route());
 }

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -22,8 +22,8 @@ export default function Editor({
   this.render = () => {
     if (!isinitialize) {
       $editor.innerHTML = `
-            <input type="text" name="title" style="width: 600px" value="${this.state.title}" />
-            <textarea name="content" style="width:600px;height:400px;">${this.state.content}</textarea>
+            <input type="text" name="title" style="width:100%; height:3%;" value="${this.state.title}" />
+            <textarea name="content" style="width:100%; height:90%;">${this.state.content}</textarea>
         `;
       isinitialize = true;
     }

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -14,6 +14,8 @@ export default function Editor({
 
   this.setState = (nextState) => {
     this.state = nextState;
+    $editor.querySelector("[name=title]").value = this.state.title;
+    $editor.querySelector("[name=content").value = this.state.content;
     this.render();
   };
 

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -1,0 +1,48 @@
+export default function Editor({
+  $target,
+  initialState = { title: "", content: "" },
+  onEditing,
+}) {
+  const $editor = document.createElement("div");
+
+  // html이 한 번만 렌더링 되도록
+  let isinitialize = false;
+
+  this.state = initialState;
+
+  $target.appendChild($editor);
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.render = () => {
+    if (!isinitialize) {
+      $editor.innerHTML = `
+            <input type="text" name="title" style="width: 600px" value="${this.state.title}" />
+            <textarea name="content" style="width:600px;height:400px;">${this.state.content}</textarea>
+        `;
+      isinitialize = true;
+    }
+  };
+  this.render();
+
+  $editor.addEventListener("keyup", (e) => {
+    const { target } = e;
+
+    const name = target.getAttribute("name");
+
+    // state에 해당하는 name value(title, contents)가 있을 경우 동작
+    // 빈 문자열이 false로 처리되는 것 방지
+    if (this.state[name] !== undefined) {
+      const nextState = {
+        ...this.state,
+        [name]: target.value,
+      };
+
+      this.setState(nextState);
+      onEditing(this.state);
+    }
+  });
+}

--- a/src/PostEditPage.js
+++ b/src/PostEditPage.js
@@ -30,17 +30,17 @@ export default function ({ $target, initialState }) {
         const isNew = this.state.postId === "new";
 
         if (isNew) {
-          const createdPost = await request("/posts", {
+          const createdPost = await request("/documents", {
             method: "POST",
             body: JSON.stringify(post), //this.state에는 postId만 있으므로, 변경
           });
 
-          history.replaceState(null, null, `/posts/${createdPost.id}`); // 뒤로가기 시, new로 가지 않도록 지정
+          history.replaceState(null, null, `/documents/${createdPost.id}`); // 뒤로가기 시, new로 가지 않도록 지정
           removeItem(postLocalSaveKey); //temp=post-new가 이전 값을 가지고 있지 않도록 삭제
         } else {
           // update
           // 새 글 작성 후, 새로고침 시 update된 값 불러오기
-          await request(`/posts/${post.id}`, {
+          await request(`/documents/${post.id}`, {
             method: "PUT",
             body: JSON.stringify(post),
           });
@@ -76,7 +76,7 @@ export default function ({ $target, initialState }) {
     const { postId } = this.state;
 
     if (postId !== "new") {
-      const post = await request(`./posts/${postId}`);
+      const post = await request(`./documents/${postId}`);
 
       const tempPost = getItem(postLocalSaveKey, { title: "", content: "" });
 

--- a/src/PostEditPage.js
+++ b/src/PostEditPage.js
@@ -1,0 +1,62 @@
+import Editor from "./Editor.js";
+import { getItem, setItem } from "./storage.js";
+import { request } from "./api.js";
+
+export default function ({ $target, initialState }) {
+  const $page = document.createElement("div");
+
+  this.state = initialState;
+
+  // key를 조합해서 사용
+  // 다른 page로 이동 시, 이전 page의 수정 내용이 들어오는 것 방지
+  const TEMP_POST_SAVE_KEY = `temp-post-${this.state.postId}`;
+
+  const post = getItem(TEMP_POST_SAVE_KEY, { title: "", content: "" });
+
+  let timer = null;
+
+  const editor = new Editor({
+    $target,
+    initialState: post,
+    onEditing: (post) => {
+      // 입력간격이 1초가 넘었을 때, timer 작동
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+
+      timer = setTimeout(() => {
+        setItem(TEMP_POST_SAVE_KEY, { ...post, tempSaveDate: new Date() });
+      }, 1000);
+    },
+  });
+
+  this.setState = async (nextState) => {
+    if (this.state.postId !== nextState.postId) {
+      this.state = nextState;
+      await fetchPost();
+      return;
+    }
+
+    this.state = nextState;
+    this.render();
+
+    editor.setState(this.state.post);
+  };
+
+  this.render = () => {
+    $target.appendChild($page);
+  };
+
+  const fetchPost = async () => {
+    const { postId } = this.state;
+
+    if (postId !== "new") {
+      const post = await request(`./posts/${postId}`);
+
+      this.setState({
+        ...this.state,
+        post,
+      });
+    }
+  };
+}

--- a/src/PostEditPage.js
+++ b/src/PostEditPage.js
@@ -58,6 +58,17 @@ export default function ({ $target, initialState }) {
     if (postId !== "new") {
       const post = await request(`./posts/${postId}`);
 
+      const tempPost = getItem(postLocalSaveKey, { title: "", content: "" });
+
+      // tempSaveDate -> 저장한 시간
+      // updated_at -> 마지막으로 업데이트 되었던 시간
+      if (tempPost.tempSaveDate && tempPost.tempSaveDate > post.updated_at) {
+        if (confirm("저장되지 않은 임시 데이터가 있습니다. 불러올까요?")) {
+          this.setState({ ...this.state, post: tempPost });
+          return;
+        }
+      }
+
       this.setState({
         ...this.state,
         post,

--- a/src/PostEditPage.js
+++ b/src/PostEditPage.js
@@ -1,5 +1,5 @@
 import Editor from "./Editor.js";
-import { getItem, setItem } from "./storage.js";
+import { getItem, setItem, removeItem } from "./storage.js";
 import { request } from "./api.js";
 
 export default function ({ $target, initialState }) {
@@ -28,6 +28,7 @@ export default function ({ $target, initialState }) {
         setItem(postLocalSaveKey, { ...post, tempSaveDate: new Date() });
 
         const isNew = this.state.postId === "new";
+
         if (isNew) {
           const createdPost = await request("/posts", {
             method: "POST",
@@ -35,6 +36,15 @@ export default function ({ $target, initialState }) {
           });
 
           history.replaceState(null, null, `/posts/${createdPost.id}`); // 뒤로가기 시, new로 가지 않도록 지정
+          removeItem(postLocalSaveKey); //temp=post-new가 이전 값을 가지고 있지 않도록 삭제
+        } else {
+          // update
+          // 새 글 작성 후, 새로고침 시 update된 값 불러오기
+          await request(`/posts/${post.id}`, {
+            method: "PUT",
+            body: JSON.stringify(post),
+          });
+          removeItem(postLocalSaveKey); //update한 post를 localStorage에서 삭제
         }
       }, 1000);
     },

--- a/src/PostEditPage.js
+++ b/src/PostEditPage.js
@@ -33,7 +33,8 @@ export default function ({ $target, initialState }) {
   this.setState = async (nextState) => {
     if (this.state.postId !== nextState.postId) {
       // 새 글 작성 시 , temp-post-new에 저장하지 않도록 지정
-      postLocalSaveKey = `temp-post-${this.state.postId}`;
+      postLocalSaveKey = `temp-post-${nextState.postId}`;
+      console.log(this.state);
       this.state = nextState;
       await fetchPost();
       return;

--- a/src/PostEditPage.js
+++ b/src/PostEditPage.js
@@ -24,8 +24,18 @@ export default function ({ $target, initialState }) {
         clearTimeout(timer);
       }
 
-      timer = setTimeout(() => {
+      timer = setTimeout(async () => {
         setItem(postLocalSaveKey, { ...post, tempSaveDate: new Date() });
+
+        const isNew = this.state.postId === "new";
+        if (isNew) {
+          const createdPost = await request("/posts", {
+            method: "POST",
+            body: JSON.stringify(post), //this.state에는 postId만 있으므로, 변경
+          });
+
+          history.replaceState(null, null, `/posts/${createdPost.id}`); // 뒤로가기 시, new로 가지 않도록 지정
+        }
       }, 1000);
     },
   });

--- a/src/PostEditPage.js
+++ b/src/PostEditPage.js
@@ -9,9 +9,9 @@ export default function ({ $target, initialState }) {
 
   // key를 조합해서 사용
   // 다른 page로 이동 시, 이전 page의 수정 내용이 들어오는 것 방지
-  const TEMP_POST_SAVE_KEY = `temp-post-${this.state.postId}`;
+  let postLocalSaveKey = `temp-post-${this.state.postId}`;
 
-  const post = getItem(TEMP_POST_SAVE_KEY, { title: "", content: "" });
+  const post = getItem(postLocalSaveKey, { title: "", content: "" });
 
   let timer = null;
 
@@ -25,13 +25,15 @@ export default function ({ $target, initialState }) {
       }
 
       timer = setTimeout(() => {
-        setItem(TEMP_POST_SAVE_KEY, { ...post, tempSaveDate: new Date() });
+        setItem(postLocalSaveKey, { ...post, tempSaveDate: new Date() });
       }, 1000);
     },
   });
 
   this.setState = async (nextState) => {
     if (this.state.postId !== nextState.postId) {
+      // 새 글 작성 시 , temp-post-new에 저장하지 않도록 지정
+      postLocalSaveKey = `temp-post-${this.state.postId}`;
       this.state = nextState;
       await fetchPost();
       return;
@@ -40,7 +42,9 @@ export default function ({ $target, initialState }) {
     this.state = nextState;
     this.render();
 
-    editor.setState(this.state.post);
+    // default 값 지정
+    // /posts/new에서 title, content에 undefined 방지
+    editor.setState(this.state.post || { title: "", content: "" });
   };
 
   this.render = () => {

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -1,3 +1,5 @@
+import { push } from "./router.js";
+
 export default function PostList({ $target, initialState }) {
   const $postList = document.createElement("div");
   $target.appendChild($postList);
@@ -19,19 +21,11 @@ export default function PostList({ $target, initialState }) {
 
   $postList.addEventListener("click", (e) => {
     const $li = e.target.closest("li"); // postList내 클릭한 li 가져오기
-    console.log($li.dataset.id);
+
     if ($li) {
       const { id } = $li.dataset;
 
-      // custom 이벤트 발생
-      window.dispatchEvent(
-        new CustomEvent("route-change", {
-          // 이벤트 데이터로 넣을 수 있는 값
-          detail: {
-            nextUrl: `/posts/${id}`,
-          },
-        })
-      );
+      push(`/posts/${id}`);
     }
   });
 }

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -29,18 +29,30 @@ export default function PostList({ $target, initialState }) {
 
   //   this.render();
 
-  $postList.addEventListener("click", (e) => {
+  $postList.addEventListener("click", async (e) => {
     const $li = e.target.closest("li"); // postList내 클릭한 li 가져오기
-    const { id } = $li.dataset;
-    if ($li) {
-      push(`/documents/${id}`);
-    }
-
+    const $buttonAdd = e.target.closest("li > button#add");
     const $buttonDelete = e.target.closest("li > button#delete");
-    if ($buttonDelete) {
-      request(`/documents/${id}`, {
-        method: "DELETE",
-      });
+
+    const { id } = $li.dataset;
+
+    if ($li && $buttonAdd) {
+      push(`/documents/new`);
+    } else if ($li && $buttonDelete) {
+      try {
+        await request(`/documents/${id}`, {
+          method: "DELETE",
+        });
+
+        // 서버 요청이 성공하면 클라이언트 상태 업데이트
+        this.state = this.state.filter((post) => post.id !== Number(id));
+
+        this.render();
+      } catch (error) {
+        console.error("삭제 중 오류 발생:", error);
+      }
+    } else {
+      push(`/documents/${id}`);
     }
   });
 }

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -1,4 +1,4 @@
-export default function PostList({ $target, initialState }) {
+export default function PostList({ $target, initialState, onPostClick }) {
   const $postList = document.createElement("div");
   $target.appendChild($postList);
 
@@ -11,9 +11,19 @@ export default function PostList({ $target, initialState }) {
 
   this.render = () => {
     $postList.innerHTML = `<ul>${this.state
-      .map((post) => `<li>${post.title}</li>`)
+      .map((post) => `<li data-id="${post.id}">${post.title}</li>`)
       .join("")}</ul>`;
   };
 
   //   this.render();
+
+  $postList.addEventListener("click", (e) => {
+    const $li = e.target.closest("li"); // postList내 클릭한 li 가져오기
+    console.log($li.dataset.id);
+    if ($li) {
+      const { id } = $li.dataset;
+
+      onPostClick(id);
+    }
+  });
 }

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -1,4 +1,5 @@
 import { push } from "./router.js";
+import { request } from "./api.js";
 
 export default function PostList({ $target, initialState }) {
   const $postList = document.createElement("div");
@@ -12,20 +13,34 @@ export default function PostList({ $target, initialState }) {
   };
 
   this.render = () => {
-    $postList.innerHTML = `<ul>${this.state
-      .map((post) => `<li data-id="${post.id}">${post.title}</li>`)
-      .join("")}</ul>`;
+    $postList.innerHTML = `<ul>
+        ${this.state
+          .map(
+            (post) =>
+              `<li data-id="${post.id}">
+                ${post.title}
+                <button id="add">+</button>
+                <button id="delete">Delete</button>
+                
+            </li>`
+          )
+          .join("")}</ul>`;
   };
 
   //   this.render();
 
   $postList.addEventListener("click", (e) => {
     const $li = e.target.closest("li"); // postList내 클릭한 li 가져오기
-
+    const { id } = $li.dataset;
     if ($li) {
-      const { id } = $li.dataset;
+      push(`/documents/${id}`);
+    }
 
-      push(`/posts/${id}`);
+    const $buttonDelete = e.target.closest("li > button#delete");
+    if ($buttonDelete) {
+      request(`/documents/${id}`, {
+        method: "DELETE",
+      });
     }
   });
 }

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -1,4 +1,4 @@
-export default function PostList({ $target, initialState, onPostClick }) {
+export default function PostList({ $target, initialState }) {
   const $postList = document.createElement("div");
   $target.appendChild($postList);
 
@@ -23,7 +23,15 @@ export default function PostList({ $target, initialState, onPostClick }) {
     if ($li) {
       const { id } = $li.dataset;
 
-      onPostClick(id);
+      // custom 이벤트 발생
+      window.dispatchEvent(
+        new CustomEvent("route-change", {
+          // 이벤트 데이터로 넣을 수 있는 값
+          detail: {
+            nextUrl: `/posts/${id}`,
+          },
+        })
+      );
     }
   });
 }

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -1,0 +1,19 @@
+export default function PostList({ $target, initialState }) {
+  const $postList = document.createElement("div");
+  $target.appendChild($postList);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.render = () => {
+    $postList.innerHTML = `<ul>${this.state
+      .map((post) => `<li>${post.title}</li>`)
+      .join("")}</ul>`;
+  };
+
+  //   this.render();
+}

--- a/src/PostsPage.js
+++ b/src/PostsPage.js
@@ -12,11 +12,11 @@ export default function PostsPage({ $target }) {
   $page.appendChild($newPostButton);
 
   $newPostButton.addEventListener("click", () => {
-    push("/posts/new");
+    push("/documents/new");
   });
 
   const fetchPosts = async () => {
-    const posts = await request("/posts");
+    const posts = await request("/documents");
 
     postList.setState(posts);
   };

--- a/src/PostsPage.js
+++ b/src/PostsPage.js
@@ -1,10 +1,10 @@
 import PostList from "./PostList.js";
 import { request } from "./api.js";
 
-export default function PostsPage({ $target, onPostClick }) {
+export default function PostsPage({ $target }) {
   const $page = document.createElement("div");
 
-  const postList = new PostList({ $target, initialState: [], onPostClick });
+  const postList = new PostList({ $target, initialState: [] });
 
   const $newPostButton = document.createElement("button");
   $newPostButton.textContent = "New Post";

--- a/src/PostsPage.js
+++ b/src/PostsPage.js
@@ -1,10 +1,10 @@
 import PostList from "./PostList.js";
 import { request } from "./api.js";
 
-export default function PostsPage({ $target }) {
+export default function PostsPage({ $target, onPostClick }) {
   const $page = document.createElement("div");
 
-  const postList = new PostList({ $target, initialState: [] });
+  const postList = new PostList({ $target, initialState: [], onPostClick });
 
   const $newPostButton = document.createElement("button");
   $newPostButton.textContent = "New Post";

--- a/src/PostsPage.js
+++ b/src/PostsPage.js
@@ -1,5 +1,6 @@
 import PostList from "./PostList.js";
 import { request } from "./api.js";
+import { push } from "./router.js";
 
 export default function PostsPage({ $target }) {
   const $page = document.createElement("div");
@@ -9,6 +10,10 @@ export default function PostsPage({ $target }) {
   const $newPostButton = document.createElement("button");
   $newPostButton.textContent = "New Post";
   $page.appendChild($newPostButton);
+
+  $newPostButton.addEventListener("click", () => {
+    push("/posts/new");
+  });
 
   const fetchPosts = async () => {
     const posts = await request("/posts");

--- a/src/PostsPage.js
+++ b/src/PostsPage.js
@@ -1,0 +1,23 @@
+import PostList from "./PostList.js";
+import { request } from "./api.js";
+
+export default function PostsPage({ $target }) {
+  const $page = document.createElement("div");
+
+  const postList = new PostList({ $target, initialState: [] });
+
+  const $newPostButton = document.createElement("button");
+  $newPostButton.textContent = "New Post";
+  $page.appendChild($newPostButton);
+
+  const fetchPosts = async () => {
+    const posts = await request("/posts");
+
+    postList.setState(posts);
+  };
+
+  this.render = async () => {
+    await fetchPosts();
+    $target.appendChild($page);
+  };
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,20 @@
+export const API_END_POINT = "https://kdt-frontend.programmers.co.kr";
+
+export const request = async (url, options = {}) => {
+    try{
+        const res = await fetch(`${API_END_POINT}${url}`, {
+            ...options,
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
+
+        if(res.ok){
+            return await res.json();
+        }
+        throw new Error("API 처리중 뭔가 이상합니다!");
+    }
+    catch(e){
+        alert(e.message);
+    }
+};

--- a/src/api.js
+++ b/src/api.js
@@ -1,20 +1,20 @@
 export const API_END_POINT = "https://kdt-frontend.programmers.co.kr";
 
 export const request = async (url, options = {}) => {
-    try{
-        const res = await fetch(`${API_END_POINT}${url}`, {
-            ...options,
-            headers: {
-                "Content-Type": "application/json",
-            },
-        });
+  try {
+    const res = await fetch(`${API_END_POINT}${url}`, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        "x-username": "jeonghyeyeon",
+      },
+    });
 
-        if(res.ok){
-            return await res.json();
-        }
-        throw new Error("API 처리중 뭔가 이상합니다!");
+    if (res.ok) {
+      return await res.json();
     }
-    catch(e){
-        alert(e.message);
-    }
+    throw new Error("API 처리중 뭔가 이상합니다!");
+  } catch (e) {
+    alert(e.message);
+  }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,27 +1,13 @@
 // import App from "./App.js";
-import Editor from "./Editor.js";
-import { getItem, setItem } from "./storage.js";
+import PostEditPage from "./PostEditPage.js";
 
 const $target = document.querySelector("#app");
 
 // new App({ $target });
 
-const TEMP_POST_SAVE_KEY = "temp-post";
-
-const post = getItem(TEMP_POST_SAVE_KEY, { title: "", content: "" });
-
-let timer = null;
-
-new Editor({
+const postEditPage = new PostEditPage({
   $target,
-  initialState: post,
-  onEditing: (post) => {
-    if (timer !== null) {
-      clearTimeout(timer);
-    }
-
-    timer = setTimeout(() => {
-      setItem(TEMP_POST_SAVE_KEY, { ...post, tempSaveDate: new Date() });
-    }, 1000);
-  },
+  initialState: { postId: "new" },
 });
+
+postEditPage.setState({ postId: 2 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,5 @@
+import App from "./App.js";
+
+const $target = document.querySelector("#app");
+
+new App({ $target });

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,27 @@
-import App from "./App.js";
+// import App from "./App.js";
+import Editor from "./Editor.js";
+import { getItem, setItem } from "./storage.js";
 
 const $target = document.querySelector("#app");
 
-new App({ $target });
+// new App({ $target });
+
+const TEMP_POST_SAVE_KEY = "temp-post";
+
+const post = getItem(TEMP_POST_SAVE_KEY, { title: "", content: "" });
+
+let timer = null;
+
+new Editor({
+  $target,
+  initialState: post,
+  onEditing: (post) => {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+
+    timer = setTimeout(() => {
+      setItem(TEMP_POST_SAVE_KEY, { ...post, tempSaveDate: new Date() });
+    }, 1000);
+  },
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,5 @@
-// import App from "./App.js";
-import PostEditPage from "./PostEditPage.js";
+import App from "./App.js";
 
 const $target = document.querySelector("#app");
 
-// new App({ $target });
-
-const postEditPage = new PostEditPage({
-  $target,
-  initialState: { postId: "new" },
-});
-
-postEditPage.setState({ postId: 2 });
+new App({ $target });

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,26 @@
+const ROUTE_CHANGE_EVENT_NAME = "route-change";
+
+export const initRouter = (onRoute) => {
+  // nextUrl이 유효할 때만 라우팅 처리
+  // route가 매번 호출 되는 것을 방지
+  window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
+    const { nextUrl } = e.detail;
+
+    if (nextUrl) {
+      history.pushState(null, null, nextUrl);
+      onRoute();
+    }
+  });
+};
+
+export const push = (nextUrl) => {
+  // custom 이벤트 발생
+  window.dispatchEvent(
+    new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
+      // 이벤트 데이터로 넣을 수 있는 값
+      detail: {
+        nextUrl,
+      },
+    })
+  );
+};

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,18 @@
+const storage = window.localStorage;
+
+// 값을 가져오기
+// key -> 불러올 값
+// defaultValue -> 불러올 값이 없을 경우 세팅할 값)
+export const getItem = (key, defaultValue) => {
+  try {
+    const storedValue = storage.getItem(key);
+    return storedValue ? JSON.parse(storedValue) : defaultValue;
+  } catch (e) {
+    return defaultValue;
+  }
+};
+
+// 값을 JSON.stringify형태로 저장
+export const setItem = (key, value) => {
+  storage.setItem(key, JSON.stringify(value));
+};

--- a/src/storage.js
+++ b/src/storage.js
@@ -16,3 +16,8 @@ export const getItem = (key, defaultValue) => {
 export const setItem = (key, value) => {
   storage.setItem(key, JSON.stringify(value));
 };
+
+// 값 삭제
+export const removeItem = (key) => {
+  storage.removeItem(key);
+};

--- a/style.css
+++ b/style.css
@@ -1,0 +1,4 @@
+#app {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Vanilla JavaScript 노션 클로닝 프로젝트

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 기본 요구사항
- [x] 바닐라 JS만을 이용해 노션을 클로닝합니다.
- [ ] 기본적인 레이아웃은 노션과 같으며, 스타일링, 컬러값 등은 원하는대로 커스텀합니다.
- [ ] 글 단위를 Document라고 합니다. Document는 Document 여러개를 포함할 수 있습니다.
- [x] 화면 좌측에 Root Documents를 불러오는 API를 통해 루트 Documents를 렌더링합니다.
- [x] Root Document를 클릭하면 오른쪽 편집기 영역에 해당 Document의 Content를 렌더링합니다.
- [ ] 해당 Root Document에 하위 Document가 있는 경우, 해당 Document 아래에 트리 형태로 렌더링 합니다.
- [x] Document Tree에서 각 Document 우측에는 + 버튼이 있습니다. 해당 버튼을 클릭하면, 클릭한 Document의 하위 Document로 새 Document를 생성하고 편집화면으로 넘깁니다.
- [x] 편집기에는 기본적으로 저장 버튼이 없습니다. Document Save API를 이용해 지속적으로 서버에 저장되도록 합니다.
- [x] History API를 이용해 SPA 형태로 만듭니다.
- [x] 루트 URL 접속 시엔 별다른 편집기 선택이 안 된 상태입니다.
- [x] /documents/{documentId} 로 접속시, 해당 Document 의 content를 불러와 편집기에 로딩합니다.

### 보너스 요구사항
- [ ] 기본적으로 편집기는 textarea 기반으로 단순한 텍스트 편집기로 시작하되, 여력이 되면 div와 contentEditable을 조합해서 좀 더 Rich한 에디터를 만들어봅니다.
- [ ] 편집기 최하단에는 현재 편집 중인 Document의 하위 Document 링크를 렌더링하도록 추가합니다.
- [ ] 편집기 내에서 다른 Document name을 적은 경우, 자동으로 해당 Document의 편집 페이지로 이동하는 링크를 거는 기능을 추가합니다.
- [ ] 그 외 개선하거나 구현했으면 좋겠다는 부분이 있으면 적극적으로 구현해봅니다!

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
